### PR TITLE
send a shutdown command to a selenium server on the same port it was opened

### DIFF
--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -117,7 +117,7 @@ function start(options: Options) {
   process.stdin.resume();
   process.stdin.on('data', (chunk: Buffer) => {
     logger.info('Attempting to shut down selenium nicely');
-    http.get('http://localhost:4444/selenium-server/driver/?cmd=shutDownSeleniumServer');
+    http.get('http://localhost:'+seleniumPort+'/selenium-server/driver/?cmd=shutDownSeleniumServer');
   });
   process.on('SIGINT', () => {
     logger.info('Staying alive until the Selenium Standalone process exits');

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -117,7 +117,8 @@ function start(options: Options) {
   process.stdin.resume();
   process.stdin.on('data', (chunk: Buffer) => {
     logger.info('Attempting to shut down selenium nicely');
-    http.get('http://localhost:'+seleniumPort+'/selenium-server/driver/?cmd=shutDownSeleniumServer');
+    var port = seleniumPort || '4444';
+    http.get('http://localhost:' + port + '/selenium-server/driver/?cmd=shutDownSeleniumServer');
   });
   process.on('SIGINT', () => {
     logger.info('Staying alive until the Selenium Standalone process exits');


### PR DESCRIPTION
Once I spawned a few selenium servers, I was unable to shut it down gracefully. The issue appears to be in the port number.