### PR TITLE
chore(downloader): set error type to any

### DIFF
--- a/lib/files/downloader.ts
+++ b/lib/files/downloader.ts
@@ -144,11 +144,11 @@ export class Downloader {
             })
         .on('error',
             (error) => {
-              if (error.code === 'ETIMEDOUT') {
+              if ((error as any).code === 'ETIMEDOUT') {
                 logger.error('Connection timeout downloading: ' + fileUrl);
                 logger.error('Default timeout is 4 minutes.');
 
-              } else if (error.connect){
+              } else if ((error as any).connect) {
                 logger.error('Could not connect to the server to download: ' + fileUrl);
               }
               logger.error(error);


### PR DESCRIPTION
- 'code' and 'connect' is not defined as part of the 'error' type declaration
- setting error to any prevents this transpile error