### PR TITLE
refactor(gulpfile): use promises instead of callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "clang-format": "^1.0.35",
     "gulp": "^3.9.1",
     "gulp-clang-format": "^1.0.23",
+    "gulp-util": "^3.0.7",
     "jasmine": "^2.4.1",
-    "run-sequence": "^1.1.5",
     "typescript": "^1.8.7",
     "typings": "^1.0.4"
   }


### PR DESCRIPTION
- refactored gulpfile to use promises instead of callbacks
- removed dependency on runSequence
- added gulp-util package for logging messages