### PR TITLE
Add geckodriver, related config, and flags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ built/
 node_modules/
 selenium/
 typings/
+.idea/

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "webdriverVersions": {
     "selenium": "2.53.1",
     "chromedriver": "2.23",
+    "geckodriver": "v0.9.0",
     "iedriver": "2.53.1",
     "androidsdk": "24.4.1",
     "appium": "1.5.3"
@@ -9,6 +10,7 @@
   "cdnUrls": {
     "selenium": "https://selenium-release.storage.googleapis.com/",
     "chromedriver": "https://chromedriver.storage.googleapis.com/",
+    "geckodriver": "https://github.com/mozilla/geckodriver/releases/download/",
     "iedriver": "https://selenium-release.storage.googleapis.com/",
     "androidsdk": "http://dl.google.com/android/"
   }

--- a/lib/binaries/gecko_driver.ts
+++ b/lib/binaries/gecko_driver.ts
@@ -16,13 +16,13 @@ export class GeckoDriver extends Binary {
 
   static suffixes:
       {[key: string]:
-           string} = {'Darwin': 'mac.tar.gz', 'Linux': 'linux64.tar.gz', 'Windows_NT': 'win64.zip'};
+           string} = {'Darwin': '-mac.tar.gz', 'Linux': '-linux64.tar.gz', 'Windows_NT': '-win64.zip'};
 
   constructor() {
     super();
     this.name = 'geckodriver';
     this.versionCustom = GeckoDriver.versionDefault;
-    this.prefixDefault = 'geckodriver';
+    this.prefixDefault = 'geckodriver-';
     this.cdn = Config.cdnUrls().gecko;
   }
 
@@ -44,7 +44,7 @@ export class GeckoDriver extends Binary {
 
   url(ostype: string, arch: string): string {
     let urlBase = this.cdn + this.version() + '/';
-    let filename = [this.prefix(), this.version(), this.suffix(ostype, arch)].join('-');
+    let filename = this.prefix() + this.version() + this.suffix(ostype, arch);
     return urlBase + filename;
   }
 }

--- a/lib/binaries/gecko_driver.ts
+++ b/lib/binaries/gecko_driver.ts
@@ -14,9 +14,11 @@ export class GeckoDriver extends Binary {
   static isDefault = true;
   static shortName = ['chrome'];
 
-  static suffixes:
-      {[key: string]:
-           string} = {'Darwin': '-mac.tar.gz', 'Linux': '-linux64.tar.gz', 'Windows_NT': '-win64.zip'};
+  static suffixes: {[key: string]: string} = {
+    'Darwin': '-mac.tar.gz',
+    'Linux': '-linux64.tar.gz',
+    'Windows_NT': '-win64.zip'
+  };
 
   constructor() {
     super();

--- a/lib/binaries/gecko_driver.ts
+++ b/lib/binaries/gecko_driver.ts
@@ -11,7 +11,7 @@ export class GeckoDriver extends Binary {
   static os = [OS.Windows_NT, OS.Linux, OS.Darwin];
   static id = 'gecko';
   static versionDefault = Config.binaryVersions().gecko;
-  static isDefault = false;
+  static isDefault = true;
   static shortName = ['gecko'];
 
   static suffixes: {[key: string]: string} = {

--- a/lib/binaries/gecko_driver.ts
+++ b/lib/binaries/gecko_driver.ts
@@ -11,8 +11,8 @@ export class GeckoDriver extends Binary {
   static os = [OS.Windows_NT, OS.Linux, OS.Darwin];
   static id = 'gecko';
   static versionDefault = Config.binaryVersions().gecko;
-  static isDefault = true;
-  static shortName = ['chrome'];
+  static isDefault = false;
+  static shortName = ['gecko'];
 
   static suffixes: {[key: string]: string} = {
     'Darwin': '-mac.tar.gz',

--- a/lib/binaries/gecko_driver.ts
+++ b/lib/binaries/gecko_driver.ts
@@ -1,0 +1,50 @@
+import * as path from 'path';
+
+import {Config} from '../config';
+
+import {Binary, OS} from './binary';
+
+/**
+ * The gecko driver binary.
+ */
+export class GeckoDriver extends Binary {
+  static os = [OS.Windows_NT, OS.Linux, OS.Darwin];
+  static id = 'gecko';
+  static versionDefault = Config.binaryVersions().gecko;
+  static isDefault = true;
+  static shortName = ['chrome'];
+
+  static suffixes:
+      {[key: string]:
+           string} = {'Darwin': 'mac.tar.gz', 'Linux': 'linux64.tar.gz', 'Windows_NT': 'win64.zip'};
+
+  constructor() {
+    super();
+    this.name = 'geckodriver';
+    this.versionCustom = GeckoDriver.versionDefault;
+    this.prefixDefault = 'geckodriver';
+    this.cdn = Config.cdnUrls().gecko;
+  }
+
+  id(): string { return GeckoDriver.id; }
+
+  versionDefault(): string { return GeckoDriver.versionDefault; }
+
+  suffix(ostype: string, arch: string): string {
+    if (!GeckoDriver.supports(ostype, arch)) {
+      throw new Error('GeckoDriver doesn\'t support ${ostype} ${arch}!');
+    }
+
+    return GeckoDriver.suffixes[ostype];
+  }
+
+  static supports(ostype: string, arch: string): boolean {
+    return arch == 'x64' && (ostype in GeckoDriver.suffixes);
+  }
+
+  url(ostype: string, arch: string): string {
+    let urlBase = this.cdn + this.version() + '/';
+    let filename = [this.prefix(), this.version(), this.suffix(ostype, arch)].join('-');
+    return urlBase + filename;
+  }
+}

--- a/lib/binaries/ie_driver.ts
+++ b/lib/binaries/ie_driver.ts
@@ -35,7 +35,6 @@ export class IEDriver extends Binary {
         return '_x64_' + this.versionCustom;
       } else {
         return '_Win32_' + this.versionCustom;
-        ;
       }
     }
     return '';

--- a/lib/binaries/index.ts
+++ b/lib/binaries/index.ts
@@ -1,5 +1,6 @@
 export * from './binary';
 export * from './chrome_driver';
+export * from './gecko_driver';
 export * from './ie_driver';
 export * from './android_sdk';
 export * from './appium';

--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -58,7 +58,6 @@ opts[ANDROID] = new Option(ANDROID, 'Update/use the android sdk', 'boolean', And
 opts[IOS] = new Option(IOS, 'Update the iOS sdk', 'boolean', false);
 opts[VERSIONS_CHROME] = new Option(
     VERSIONS_CHROME, 'Optional chrome driver version', 'string', ChromeDriver.versionDefault);
-console.log(GeckoDriver.versionDefault);
 opts[VERSIONS_GECKO] = new Option(
     VERSIONS_GECKO, 'Optional gecko driver version', 'string', GeckoDriver.versionDefault);
 opts[VERSIONS_ANDROID] = new Option(

--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -1,4 +1,4 @@
-import {AndroidSDK, Appium, ChromeDriver, IEDriver, StandAlone} from '../binaries';
+import {AndroidSDK, Appium, ChromeDriver, GeckoDriver, IEDriver, StandAlone} from '../binaries';
 import {Cli, Option, Options} from '../cli';
 import {Config} from '../config';
 
@@ -18,6 +18,7 @@ export const GECKO = 'gecko';
 export const ANDROID = 'android';
 export const IOS = 'ios';
 export const VERSIONS_CHROME = 'versions.chrome';
+export const VERSIONS_GECKO = 'versions.gecko';
 export const VERSIONS_STANDALONE = 'versions.standalone';
 export const VERSIONS_IE = 'versions.ie';
 export const VERSIONS_ANDROID = 'versions.android';
@@ -47,16 +48,19 @@ opts[STANDALONE] = new Option(
     STANDALONE, 'Install or update selenium standalone', 'boolean', StandAlone.isDefault);
 opts[CHROME] =
     new Option(CHROME, 'Install or update chromedriver', 'boolean', ChromeDriver.isDefault);
+opts[GECKO] = new Option(GECKO, 'Install or update geckodriver', 'string', GeckoDriver.isDefault);
 opts[IE] = new Option(IE, 'Install or update ie driver', 'boolean', IEDriver.isDefault);
 opts[IE32] = new Option(IE32, 'Install or update 32-bit ie driver', 'boolean', IEDriver.isDefault);
 opts[EDGE] = new Option(
     EDGE, 'Use installed Microsoft Edge driver', 'string',
     'C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe');
-opts[GECKO] = new Option(GECKO, 'Use path for gecko driver', 'string');
 opts[ANDROID] = new Option(ANDROID, 'Update/use the android sdk', 'boolean', AndroidSDK.isDefault);
 opts[IOS] = new Option(IOS, 'Update the iOS sdk', 'boolean', false);
 opts[VERSIONS_CHROME] = new Option(
     VERSIONS_CHROME, 'Optional chrome driver version', 'string', ChromeDriver.versionDefault);
+console.log(GeckoDriver.versionDefault);
+opts[VERSIONS_GECKO] = new Option(
+    VERSIONS_GECKO, 'Optional gecko driver version', 'string', GeckoDriver.versionDefault);
 opts[VERSIONS_ANDROID] = new Option(
     VERSIONS_ANDROID, 'Optional android sdk version', 'string', AndroidSDK.versionDefault);
 opts[VERSIONS_STANDALONE] = new Option(

--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -48,7 +48,7 @@ opts[STANDALONE] = new Option(
     STANDALONE, 'Install or update selenium standalone', 'boolean', StandAlone.isDefault);
 opts[CHROME] =
     new Option(CHROME, 'Install or update chromedriver', 'boolean', ChromeDriver.isDefault);
-opts[GECKO] = new Option(GECKO, 'Install or update geckodriver', 'string', GeckoDriver.isDefault);
+opts[GECKO] = new Option(GECKO, 'Install or update geckodriver', 'boolean', GeckoDriver.isDefault);
 opts[IE] = new Option(IE, 'Install or update ie driver', 'boolean', IEDriver.isDefault);
 opts[IE32] = new Option(IE32, 'Install or update 32-bit ie driver', 'boolean', IEDriver.isDefault);
 opts[EDGE] = new Option(

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -6,13 +6,13 @@ import * as os from 'os';
 import * as path from 'path';
 
 import {AndroidSDK, Appium, Binary, BinaryMap, ChromeDriver, IEDriver, StandAlone} from '../binaries';
+import {GeckoDriver} from '../binaries/gecko_driver';
 import {Logger, Options, Program} from '../cli';
 import {Config} from '../config';
 import {FileManager} from '../files';
 
 import * as Opt from './';
 import {Opts} from './opts';
-import {GeckoDriver} from "../binaries/gecko_driver";
 
 let logger = new Logger('start');
 let prog = new Program()
@@ -135,8 +135,8 @@ function start(options: Options) {
   }
   if (downloadedBinaries[GeckoDriver.id] != null) {
     args.push(
-      '-Dwebdriver.gecko.driver=' +
-      path.join(outputDir, binaries[GeckoDriver.id].executableFilename(osType)));
+        '-Dwebdriver.gecko.driver=' +
+        path.join(outputDir, binaries[GeckoDriver.id].executableFilename(osType)));
   }
   if (downloadedBinaries[IEDriver.id] != null) {
     if (options[Opt.IE32]) {

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -12,6 +12,7 @@ import {FileManager} from '../files';
 
 import * as Opt from './';
 import {Opts} from './opts';
+import {GeckoDriver} from "../binaries/gecko_driver";
 
 let logger = new Logger('start');
 let prog = new Program()
@@ -131,6 +132,11 @@ function start(options: Options) {
     if (chromeLogs != null) {
       args.push('-Dwebdriver.chrome.logfile=' + chromeLogs);
     }
+  }
+  if (downloadedBinaries[GeckoDriver.id] != null) {
+    args.push(
+      '-Dwebdriver.gecko.driver=' +
+      path.join(outputDir, binaries[GeckoDriver.id].executableFilename(osType)));
   }
   if (downloadedBinaries[IEDriver.id] != null) {
     if (options[Opt.IE32]) {

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -26,7 +26,6 @@ let prog = new Program()
                .addOption(Opts[Opt.VERSIONS_ANDROID])
                .addOption(Opts[Opt.VERSIONS_APPIUM])
                .addOption(Opts[Opt.CHROME_LOGS])
-               .addOption(Opts[Opt.GECKO])
                .addOption(Opts[Opt.LOGGING])
                .addOption(Opts[Opt.ANDROID])
                .addOption(Opts[Opt.AVDS])
@@ -151,17 +150,6 @@ function start(options: Options) {
     } catch (err) {
       // Either the default file or user specified location of the edge
       // driver does not exist.
-    }
-  }
-  if (options[Opt.GECKO].getString()) {
-    let gecko = options[Opt.GECKO].getString();
-    try {
-      if (fs.statSync(gecko).isFile()) {
-        args.push('-Dwebdriver.edge.driver=' + gecko);
-      }
-    } catch (err) {
-      // The file does not exist.
-      logger.warn('The absolute path provided for gecko (' + gecko + ') does not exist');
     }
   }
   if (options[Opt.ANDROID].getBoolean()) {

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as q from 'q';
 import * as rimraf from 'rimraf';
 
-import {AndroidSDK, Appium, Binary, ChromeDriver, IEDriver, StandAlone} from '../binaries';
+import {AndroidSDK, Appium, Binary, ChromeDriver, GeckoDriver, IEDriver, StandAlone} from '../binaries';
 import {Logger, Options, Program} from '../cli';
 import {Config} from '../config';
 import {Downloader, FileManager} from '../files';
@@ -30,6 +30,10 @@ let prog = new Program()
                .addOption(Opts[Opt.ANDROID_API_LEVELS])
                .addOption(Opts[Opt.ANDROID_ABIS])
                .addOption(Opts[Opt.ANDROID_ACCEPT_LICENSES]);
+
+if (GeckoDriver.supports(os.type(), os.arch())) {
+  prog.addOption(Opts[Opt.VERSIONS_GECKO]).addOption(Opts[Opt.GECKO])
+}
 
 if (os.type() === 'Darwin') {
   prog.addOption(Opts[Opt.IOS]);

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -32,7 +32,7 @@ let prog = new Program()
                .addOption(Opts[Opt.ANDROID_ACCEPT_LICENSES]);
 
 if (GeckoDriver.supports(os.type(), os.arch())) {
-  prog.addOption(Opts[Opt.VERSIONS_GECKO]).addOption(Opts[Opt.GECKO])
+  prog.addOption(Opts[Opt.VERSIONS_GECKO]).addOption(Opts[Opt.GECKO]);
 }
 
 if (os.type() === 'Darwin') {

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -69,6 +69,7 @@ if (argv._[0] === 'update-run') {
 function update(options: Options): void {
   let standalone = options[Opt.STANDALONE].getBoolean();
   let chrome = options[Opt.CHROME].getBoolean();
+  let gecko = options[Opt.GECKO].getBoolean();
   let ie: boolean = false;
   let ie32: boolean = false;
   if (options[Opt.IE]) {
@@ -104,6 +105,9 @@ function update(options: Options): void {
   if (options[Opt.VERSIONS_IE]) {
     binaries[IEDriver.id].versionCustom = options[Opt.VERSIONS_IE].getString();
   }
+  if (options[Opt.VERSIONS_GECKO]) {
+    binaries[GeckoDriver.id].versionCustom = options[Opt.VERSIONS_GECKO].getString();
+  }
   binaries[AndroidSDK.id].versionCustom = options[Opt.VERSIONS_ANDROID].getString();
   binaries[Appium.id].versionCustom = options[Opt.VERSIONS_APPIUM].getString();
 
@@ -125,6 +129,10 @@ function update(options: Options): void {
   }
   if (chrome) {
     let binary = binaries[ChromeDriver.id];
+    updateBinary(binary, outputDir, proxy, ignoreSSL);
+  }
+  if (gecko) {
+    let binary = binaries[GeckoDriver.id];
     updateBinary(binary, outputDir, proxy, ignoreSSL);
   }
   if (ie) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -9,6 +9,7 @@ let logger = new Logger('config');
 export interface ConfigFile {
   selenium?: string;
   chrome?: string;
+  gecko?: string;
   ie?: string;
   android?: string;
   appium?: string;
@@ -53,6 +54,7 @@ export class Config {
     let configVersions: ConfigFile = {};
     configVersions.selenium = configFile.webdriverVersions.selenium;
     configVersions.chrome = configFile.webdriverVersions.chromedriver;
+    configVersions.gecko = configFile.webdriverVersions.geckodriver;
     configVersions.ie = configFile.webdriverVersions.iedriver;
     configVersions.android = configFile.webdriverVersions.androidsdk;
     configVersions.appium = configFile.webdriverVersions.appium;
@@ -68,6 +70,7 @@ export class Config {
     let configCdnUrls: ConfigFile = {};
     configCdnUrls.selenium = configFile.cdnUrls.selenium;
     configCdnUrls.chrome = configFile.cdnUrls.chromedriver;
+    configCdnUrls.gecko = configFile.cdnUrls.geckodriver;
     configCdnUrls.ie = configFile.cdnUrls.iedriver;
     configCdnUrls.android = configFile.cdnUrls.androidsdk;
     return configCdnUrls;

--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -9,7 +9,7 @@ import {Binary, BinaryMap, ChromeDriver, IEDriver, AndroidSDK, Appium, StandAlon
 import {DownloadedBinary} from './downloaded_binary';
 import {Downloader} from './downloader';
 import {Logger} from '../cli';
-import {GeckoDriver} from "../binaries/gecko_driver";
+import {GeckoDriver} from '../binaries/gecko_driver';
 
 let logger = new Logger('file_manager');
 

--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -9,6 +9,7 @@ import {Binary, BinaryMap, ChromeDriver, IEDriver, AndroidSDK, Appium, StandAlon
 import {DownloadedBinary} from './downloaded_binary';
 import {Downloader} from './downloader';
 import {Logger} from '../cli';
+import {GeckoDriver} from "../binaries/gecko_driver";
 
 let logger = new Logger('file_manager');
 
@@ -60,6 +61,9 @@ export class FileManager {
     }
     if (FileManager.checkOS_(osType, ChromeDriver)) {
       binaries[ChromeDriver.id] = new ChromeDriver();
+    }
+    if (FileManager.checkOS_(osType, GeckoDriver)) {
+      binaries[GeckoDriver.id] = new GeckoDriver();
     }
     if (FileManager.checkOS_(osType, IEDriver)) {
       binaries[IEDriver.id] = new IEDriver();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
-    "sourceMap": false,
+    "sourceMap": true,
     "declaration": true,
     "removeComments": false,
     "noImplicitAny": true,


### PR DESCRIPTION
geckodriver is still a little experimental, so I've disabled it by default. You need "marionette: true" in your capabilities in order to use it. Also, there's a bug where after we delete the session at the end of the test, geckodriver won't run again so you need to restart selenium. 