### PR TITLE
fix(chrome_driver): use the x64 binary if chrome driver version is greater than 2.23

### DIFF
--- a/lib/binaries/chrome_driver.ts
+++ b/lib/binaries/chrome_driver.ts
@@ -30,7 +30,13 @@ export class ChromeDriver extends Binary {
 
   suffix(ostype: string, arch: string): string {
     if (ostype === 'Darwin') {
-      return 'mac32' + this.suffixDefault;
+      // after chromedriver version 2.23, the name of the binary changed
+      // They no longer provide a 32 bit binary
+      if (parseFloat(this.version()) >= 2.23) {
+        return 'mac64' + this.suffixDefault;
+      } else {
+        return 'mac32' + this.suffixDefault;
+      }
     } else if (ostype === 'Linux') {
       if (arch === 'x64') {
         return 'linux64' + this.suffixDefault;


### PR DESCRIPTION
I don't know if this is the ideal way to fix this, but I did manage to get it to download correctly.

```sh
webdriver-manager ⚑ → ./bin/webdriver-manager update                                                          master ✗
webdriver-manager: using project version 10.2.3
[12:26:35] I/file_manager - creating folder /path/to/webdriver-manager/selenium
[12:26:35] I/downloader - selenium standalone: downloading version 2.53.1
[12:26:35] I/downloader - curl -o /path/to/webdriver-manager/selenium/selenium-server-standalone-2.53.1.jar https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar
[12:26:35] I/downloader - chromedriver: downloading version 2.24
[12:26:35] I/downloader - curl -o /path/to/webdriver-manager/selenium/chromedriver_2.24mac64.zip https://chromedriver.storage.googleapis.com/2.24/chromedriver_mac64.zip
[12:26:35] I/downloader - geckodriver: downloading version v0.9.0
[12:26:35] I/downloader - curl -o /path/to/webdriver-manager/selenium/geckodriver-v0.9.0-mac.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.9.0/geckodriver-v0.9.0-mac.tar.gz
[12:26:36] I/update - chromedriver: unzipping /path/to/webdriver-manager/selenium/chromedriver_2.24mac64.zip
[12:26:36] I/update - chromedriver: setting permissions to 0755 for /path/to/webdriver-manager/selenium/chromedriver_2.24
[12:26:36] I/update - geckodriver: unzipping /path/to/webdriver-manager/selenium/geckodriver-v0.9.0-mac.tar.gz
[12:26:36] I/update - geckodriver: setting permissions to 0755 for /path/to/webdriver-manager/selenium/geckodriver-v0.9.0
```