### PR TITLE
fix(filemanager): respect proxy/ignoreSSL options in httpHeadContentLength

### DIFF
--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -116,7 +116,7 @@ function update(options: Options): void {
   // permissions
   if (standalone) {
     let binary = binaries[StandAlone.id];
-    FileManager.toDownload(binary, outputDir).then((value: boolean) => {
+    FileManager.toDownload(binary, outputDir, proxy, ignoreSSL).then((value: boolean) => {
       if (value) {
         Downloader.downloadBinary(binary, outputDir, proxy, ignoreSSL);
       } else {
@@ -165,7 +165,7 @@ function update(options: Options): void {
 
 function updateBinary(
     binary: Binary, outputDir: string, proxy: string, ignoreSSL: boolean): q.Promise<any> {
-  return FileManager.toDownload(binary, outputDir).then((value: boolean) => {
+  return FileManager.toDownload(binary, outputDir, proxy, ignoreSSL).then((value: boolean) => {
     if (value) {
       let deferred = q.defer();
       Downloader.downloadBinary(

--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -166,7 +166,7 @@ export class FileManager {
    * @param outputDir The directory where files are downloaded and stored.
    * @returns If the file should be downloaded.
    */
-  static toDownload<T extends Binary>(binary: T, outputDir: string): q.Promise<boolean> {
+  static toDownload<T extends Binary>(binary: T, outputDir: string, proxy: string, ignoreSSL: boolean): q.Promise<boolean> {
     let osType = os.type();
     let osArch = os.arch();
     let filePath: string;
@@ -185,7 +185,7 @@ export class FileManager {
           readData = fs.readFileSync(filePath);
 
           // we have the version, verify it is the correct file size
-          let contentLength = Downloader.httpHeadContentLength(binary.url(osType, osArch));
+          let contentLength = Downloader.httpHeadContentLength(binary.url(osType, osArch), proxy, ignoreSSL);
           return contentLength.then((value: any): boolean => {
             if (value == readData.length) {
               return false;


### PR DESCRIPTION
Using `--ignore_ssl` option can work around [UNABLE_TO_GET_ISSUER_CERT_LOCALLY error](https://gist.github.com/royling/b8281915a76792ba54626dcfe39ecf24), that could be encountered in a corporate network. But this only works at a fresh run, the subsequent run failed.

That's because the proxy/ignoreSSL options are not passed in `Downloader.httpHeadContentLength()`, which is to fire a HEAD request for content-length field for size checking.

This change fixed the problem.