### PR TITLE
fix(cli): fix default option values, boolean and string handling (#110)

### DIFF
--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -125,6 +125,7 @@ export class Cli {
     let minimistBoolean: string[] = [];
     let minimistString: string[] = [];
     let minimistNumber: string[] = [];
+    let minimistDefault: any = {};
     for (let opt in allOptions) {
       let option = allOptions[opt];
       if (option.type === 'boolean') {
@@ -134,10 +135,14 @@ export class Cli {
       } else if (option.type === 'number') {
         minimistNumber.push(option.opt);
       }
+      if (typeof option.defaultValue !== 'undefined') {
+        minimistDefault[option.opt] = option.defaultValue;
+      }
     }
     minimistOptions['boolean'] = minimistBoolean;
     minimistOptions['string'] = minimistString;
     minimistOptions['number'] = minimistNumber;
+    minimistOptions['default'] = minimistDefault;
     return minimistOptions;
   }
 }

--- a/lib/cli/options.ts
+++ b/lib/cli/options.ts
@@ -22,7 +22,7 @@ export class Option {
   }
 
   getValue_(): number|string|boolean {
-    if (this.value) {
+    if (typeof this.value !== 'undefined') {
       return this.value;
     } else {
       return this.defaultValue;
@@ -42,11 +42,11 @@ export class Option {
     if (value && typeof value === 'string') {
       return '' + value;
     }
-    return null;
+    return '';
   }
 
   getBoolean(): boolean {
     let value = this.getValue_();
-    return value ? true : false;
+    return Boolean(value);
   }
 }

--- a/lib/cli/programs.ts
+++ b/lib/cli/programs.ts
@@ -225,6 +225,7 @@ export class Program {
     let minimistBoolean: string[] = [];
     let minimistString: string[] = [];
     let minimistNumber: string[] = [];
+    let minimistDefault: any = {};
     for (let opt in allOptions) {
       let option = allOptions[opt];
       if (option.type === 'boolean') {
@@ -234,10 +235,14 @@ export class Program {
       } else if (option.type === 'number') {
         minimistNumber.push(option.opt);
       }
+      if (typeof option.defaultValue !== 'undefined') {
+        minimistDefault[option.opt] = option.defaultValue;
+      }
     }
     minimistOptions['boolean'] = minimistBoolean;
     minimistOptions['string'] = minimistString;
     minimistOptions['number'] = minimistNumber;
+    minimistOptions['default'] = minimistDefault;
     return minimistOptions;
   }
 }


### PR DESCRIPTION
- default option values initialize properly for `minimist`
- user-supplied boolean-type option values respected
- string-type option values are always strings
- simplify boolean-type option value access
