### PR TITLE
chore(infrastructure): Fixed a few minor, related-ish problems

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,17 +28,19 @@ gulp.task('copy', function() {
       .pipe(gulp.dest('built/'));
 });
 
+var tsGlobs = ['lib/**/*.ts', 'spec/**/*.ts'];
+
 gulp.task('format:enforce', () => {
   const format = require('gulp-clang-format');
   const clangFormat = require('clang-format');
-  return gulp.src(['lib/**/*.ts']).pipe(
+  return gulp.src(tsGlobs).pipe(
     format.checkFormat('file', clangFormat, {verbose: true, fail: true}));
 });
 
 gulp.task('format', () => {
   const format = require('gulp-clang-format');
   const clangFormat = require('clang-format');
-  return gulp.src(['lib/**/*.ts'], { base: '.' }).pipe(
+  return gulp.src(tsGlobs, { base: '.' }).pipe(
     format.format('file', clangFormat)).pipe(gulp.dest('.'));
 });
 

--- a/lib/cli_instance.ts
+++ b/lib/cli_instance.ts
@@ -1,0 +1,16 @@
+import {Cli} from './cli';
+import * as clean from './cmds/clean';
+import * as shutdown from './cmds/shutdown';
+import * as start from './cmds/start';
+import * as status from './cmds/status';
+import * as update from './cmds/update';
+import * as version from './cmds/version';
+
+export let cli = new Cli()
+                     .usage('webdriver-manager <command> [options]')
+                     .program(clean.program)
+                     .program(start.program)
+                     .program(shutdown.program)
+                     .program(status.program)
+                     .program(update.program)
+                     .program(version.program);

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -343,7 +343,7 @@ function detachedRun(options: Options) {
   let args: string[] = [file, commandName].concat(unparseOptions(options));
 
   var unreffed = false;
-  let child = childProcess.spawn(process.execPath, args, ({stdio: ['ignore', 1, 2, 'ipc']} as any));
+  let child = spawn(process.execPath, args, ['ignore', 1, 2, 'ipc']);
 
   child.on('message', (message: string) => {
     if (message == options[Opt.STARTED_SIGNIFIER].getString()) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,10 +4,10 @@ import * as os from 'os';
 
 
 function spawnFactory(sync: false):
-    (cmd: string, args: string[], stdio?: string, opts?: child_process.SpawnOptions) =>
+    (cmd: string, args: string[], stdio?: any, opts?: child_process.SpawnOptions) =>
         child_process.ChildProcess;
 function spawnFactory(sync: true):
-    (cmd: string, args: string[], stdio?: string, opts?: child_process.SpawnSyncOptions) =>
+    (cmd: string, args: string[], stdio?: any, opts?: child_process.SpawnSyncOptions) =>
         child_process.SpawnSyncReturns<any>;
 function spawnFactory(sync: boolean):
     (cmd: string, args: string[], stdio?: string,

--- a/lib/webdriver.ts
+++ b/lib/webdriver.ts
@@ -1,22 +1,6 @@
 import * as minimist from 'minimist';
 
-import {Cli} from './cli';
-import * as clean from './cmds/clean';
-import * as shutdown from './cmds/shutdown';
-import * as start from './cmds/start';
-import * as status from './cmds/status';
-import * as update from './cmds/update';
-import * as version from './cmds/version';
-import {Config} from './config';
-
-let commandline = new Cli()
-                      .usage('webdriver-manager <command> [options]')
-                      .program(clean.program)
-                      .program(start.program)
-                      .program(shutdown.program)
-                      .program(status.program)
-                      .program(update.program)
-                      .program(version.program);
+import {cli as commandline} from './cli_instance';
 
 let minimistOptions = commandline.getMinimistOptions();
 let argv = minimist(process.argv.slice(2), minimistOptions);
@@ -32,5 +16,3 @@ if (commandline.programs[cmd[0]]) {
 } else {
   commandline.printHelp();
 }
-
-export var cli = commandline;

--- a/spec/cli/programs_spec.ts
+++ b/spec/cli/programs_spec.ts
@@ -4,17 +4,16 @@ import {Option, Options, Program} from '../../lib/cli';
 describe('program', () => {
   let program: Program;
 
-  beforeEach(() => {
-    program = new Program()
-      .command('fooCmd', 'fooDescription')
-      .addOption(new Option('fooString1', 'fooDescription', 'string', 'foo'))
-      .addOption(new Option('fooString1', 'fooDescription', 'string', 'foo'))
-      .addOption(new Option('fooBoolean1', 'fooDescription', 'boolean', false))
-      .addOption(new Option('fooBoolean2', 'fooDescription', 'boolean', true))
-      .addOption(new Option('fooNumber1', 'fooDescription', 'number', 1))
-      .addOption(new Option('fooNumber2', 'fooDescription', 'number', 2))
-      .addOption(new Option('fooNumber3', 'fooDescription', 'number', 3))
-  });
+  beforeEach(
+      () => {program = new Program()
+                           .command('fooCmd', 'fooDescription')
+                           .addOption(new Option('fooString1', 'fooDescription', 'string', 'foo'))
+                           .addOption(new Option('fooString1', 'fooDescription', 'string', 'foo'))
+                           .addOption(new Option('fooBoolean1', 'fooDescription', 'boolean', false))
+                           .addOption(new Option('fooBoolean2', 'fooDescription', 'boolean', true))
+                           .addOption(new Option('fooNumber1', 'fooDescription', 'number', 1))
+                           .addOption(new Option('fooNumber2', 'fooDescription', 'number', 2))
+                           .addOption(new Option('fooNumber3', 'fooDescription', 'number', 3))});
 
   it('should get minimist options', () => {
     let json = JSON.parse(JSON.stringify(program.getMinimistOptions()));
@@ -52,7 +51,7 @@ describe('program', () => {
       expect(options['fooNumber1'].getNumber()).toEqual(10);
       expect(options['fooNumber2'].getNumber()).toEqual(20);
       expect(options['fooNumber3'].getNumber()).toEqual(30);
-    }
+    };
     program.action(callbackTest);
     program.run(json);
   });
@@ -75,7 +74,7 @@ describe('program', () => {
       expect(options['fooNumber1'].getNumber()).toEqual(100);
       expect(options['fooNumber2'].getNumber()).toEqual(NaN);
       expect(options['fooNumber3'].getNumber()).toEqual(null);
-    }
+    };
     program.action(callbackTest);
     program.run(json);
   });

--- a/spec/files/downloader_spec.ts
+++ b/spec/files/downloader_spec.ts
@@ -8,7 +8,7 @@ describe('downloader', () => {
   let envHttpProxy = 'http://foobar.env';
   let envHttpsProxy = 'https://foobar.env';
 
-  it ('should return undefined when proxy arg is not used', () => {
+  it('should return undefined when proxy arg is not used', () => {
     let proxy = Downloader.resolveProxy_(fileUrlHttp);
     expect(proxy).toBeUndefined();
   });

--- a/spec/files/fileManager_spec.ts
+++ b/spec/files/fileManager_spec.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Binary, AndroidSDK, ChromeDriver, IEDriver, Appium, StandAlone } from '../../lib/binaries';
-import { DownloadedBinary, FileManager } from '../../lib/files';
-import { BinaryMap } from '../../lib/binaries/binary';
-import { Config } from '../../lib/config';
-import { GeckoDriver } from '../../lib/binaries/gecko_driver';
+
+import {AndroidSDK, Appium, Binary, ChromeDriver, IEDriver, StandAlone} from '../../lib/binaries';
+import {BinaryMap} from '../../lib/binaries/binary';
+import {GeckoDriver} from '../../lib/binaries/gecko_driver';
+import {Config} from '../../lib/config';
+import {DownloadedBinary, FileManager} from '../../lib/files';
 
 
 describe('file manager', () => {
@@ -87,7 +88,8 @@ describe('file manager', () => {
       arch = 'x64';
       existingFiles = [
         selenium.prefix() + '2.51.0' + selenium.executableSuffix(),
-        selenium.prefix() + '2.52.0' + selenium.executableSuffix()];
+        selenium.prefix() + '2.52.0' + selenium.executableSuffix()
+      ];
       existingFiles.push(chrome.prefix() + '2.20' + chrome.suffix(ostype, arch));
       existingFiles.push(chrome.prefix() + '2.20' + chrome.executableSuffix(ostype));
       existingFiles.push(chrome.prefix() + '2.21' + chrome.suffix(ostype, arch));
@@ -251,7 +253,7 @@ describe('file manager', () => {
 
       it('should configure the CDN for each binary', () => {
         let customCDN = 'https://my.corporate.cdn/';
-        let binaries  = FileManager.compileBinaries_('Windows_NT', customCDN);
+        let binaries = FileManager.compileBinaries_('Windows_NT', customCDN);
 
         forEachOf(binaries, binary => expect(binary.cdn).toEqual(customCDN, binary.name));
       });

--- a/spec/webdriver_spec.ts
+++ b/spec/webdriver_spec.ts
@@ -1,17 +1,14 @@
-import * as child_process from 'child_process';
 import * as path from 'path';
-import {cli} from '../lib/webdriver';
-
-function runSpawn(task: string, opt_arg: string[]): string[] {
-  opt_arg = typeof opt_arg !== 'undefined' ? opt_arg : [];
-  let child = child_process.spawnSync(task, opt_arg, {stdio: 'pipe'});
-  return child.output[1].toString().split('\n');
-};
+import {cli} from '../lib/cli_instance';
+import {spawnSync} from '../lib/utils';
 
 describe('cli', () => {
   describe('help', () => {
-    it ('should have usage and commands', () => {
-      let lines = runSpawn('node', ['built/lib/webdriver.js', 'help']);
+    it('should have usage and commands', () => {
+      let lines = spawnSync(process.execPath, ['built/lib/webdriver.js', 'help'], 'pipe')
+                      .output[1]
+                      .toString()
+                      .split('\n');
 
       // very specific to make sure the
       let index = 0;


### PR DESCRIPTION
* In the rebase of 232946b against 1f9713a, an unwrapped `spawn()` was introducted
* This unwrapped `spawn()` required that our internal `spawn()` needed a fix to its signature
* There was also an unwrapped `spawn()` in `spec/webdriver_spec.ts`
* While fixing that, I got annoyed with the console output `spec/webdriver_spec.ts` produces so I
  refactored it away
* I also noticed that clang wasn't running against the spec files, and fixed that
* I also ran clang against the spec files