### PR TITLE
feat(update): on update, write full binary paths to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 built/
 node_modules/
 selenium/
+selenium_test/
 typings/
 .idea/
+npm-debug.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,9 +99,8 @@ gulp.task('test:e2e:headless', function(done) {
 });
 
 
-gulp.task('test', ['format', 'test:unit', 'test:e2e']);
-gulp.task('test:no_update', ['format', 'test:unit', 'test:e2e:no_update']);
-gulp.task('test:headless', ['format', 'test:unit', 'test:e2e:headless']);
-// gulp.task('test:headless', function(done) {
-//   runSequence('format', 'test:unit', 'test:e2e:headless', done);
-// });
+gulp.task('test', ['test:unit', 'test:e2e']);
+gulp.task('test:no_update', ['test:unit', 'test:e2e:no_update']);
+gulp.task('test:headless', function(done) {
+  runSequence('test:unit', 'test:e2e:headless', done);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,6 +101,7 @@ gulp.task('test:e2e:headless', function(done) {
 
 gulp.task('test', ['format', 'test:unit', 'test:e2e']);
 gulp.task('test:no_update', ['format', 'test:unit', 'test:e2e:no_update']);
-gulp.task('test:headless', function(done) {
-  runSequence('format', 'test:unit', 'test:e2e:headless', done);
-});
+gulp.task('test:headless', ['format', 'test:unit', 'test:e2e:headless']);
+// gulp.task('test:headless', function(done) {
+//   runSequence('format', 'test:unit', 'test:e2e:headless', done);
+// });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,7 @@ gulp.task('shutdown', ['build'], function(done) {
 });
 
 // Test
-gulp.task('test:unit', ['build'], function(done) {
+gulp.task('test:unit', ['format', 'build'], function(done) {
   runSpawn(process.execPath, ['node_modules/jasmine/bin/jasmine.js'], done);
 });
 
@@ -101,4 +101,6 @@ gulp.task('test:e2e:headless', function(done) {
 
 gulp.task('test', ['format', 'test:unit', 'test:e2e']);
 gulp.task('test:no_update', ['format', 'test:unit', 'test:e2e:no_update']);
-gulp.task('test:headless', ['format', 'test:unit', 'test:e2e:headless']);
+gulp.task('test:headless', function(done) {
+  runSequence('format', 'test:unit', 'test:e2e:headless', done);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,6 +101,4 @@ gulp.task('test:e2e:headless', function(done) {
 
 gulp.task('test', ['test:unit', 'test:e2e']);
 gulp.task('test:no_update', ['test:unit', 'test:e2e:no_update']);
-gulp.task('test:headless', function(done) {
-  runSequence('test:unit', 'test:e2e:headless', done);
-});
+gulp.task('test:headless', ['test:unit', 'test:e2e:headless']);

--- a/lib/cli/programs.ts
+++ b/lib/cli/programs.ts
@@ -71,11 +71,11 @@ export class Program {
    * method.
    * @param args The arguments that will be parsed to run the method.
    */
-  run(json: JSON): void {
+  run(json: JSON): Promise<void> {
     for (let opt in this.options) {
       this.options[opt].value = this.getValue_(opt, json);
     }
-    this.runMethod(this.options);
+    return Promise.resolve(this.runMethod(this.options));
   }
 
   private getValue_(key: string, json: JSON): number|boolean|string {

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -67,8 +67,8 @@ let browserFile: BrowserFile;
  * Parses the options and downloads binaries if they do not exist.
  * @param options
  */
-function update(options: Options): q.IPromise<void> {
-  let promises: any[] = [];
+function update(options: Options): Promise<void> {
+  let promises: q.IPromise<void>[] = [];
   let standalone = options[Opt.STANDALONE].getBoolean();
   let chrome = options[Opt.CHROME].getBoolean();
   let gecko = options[Opt.GECKO].getBoolean();

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -61,12 +61,14 @@ if (argv._[0] === 'update-run') {
   prog.printHelp();
 }
 
+let browserFile: BrowserFile;
 
 /**
  * Parses the options and downloads binaries if they do not exist.
  * @param options
  */
-function update(options: Options): void {
+function update(options: Options): q.IPromise<void> {
+  let promises: any[] = [];
   let standalone = options[Opt.STANDALONE].getBoolean();
   let chrome = options[Opt.CHROME].getBoolean();
   let gecko = options[Opt.GECKO].getBoolean();
@@ -84,6 +86,14 @@ function update(options: Options): void {
     ios = options[Opt.IOS].getBoolean();
   }
   let outputDir = Config.getSeleniumDir();
+
+  try {
+    browserFile =
+        JSON.parse(fs.readFileSync(path.resolve(outputDir, 'update-config.json')).toString());
+  } catch (err) {
+    browserFile = {};
+  }
+
   let android_api_levels: string[] = options[Opt.ANDROID_API_LEVELS].getString().split(',');
   let android_architectures: string[] = options[Opt.ANDROID_ARCHITECTURES].getString().split(',');
   let android_platforms: string[] = options[Opt.ANDROID_PLATFORMS].getString().split(',');
@@ -118,56 +128,63 @@ function update(options: Options): void {
   // permissions
   if (standalone) {
     let binary = binaries[StandAlone.id];
-    FileManager.downloadFile(binary, outputDir, proxy, ignoreSSL).then((downloaded: boolean) => {
-      if (!downloaded) {
-        logger.info(
-            binary.name + ': file exists ' +
-            path.resolve(outputDir, binary.filename(Config.osType(), Config.osArch())));
-        logger.info(binary.name + ': v' + binary.versionCustom + ' up to date');
-      }
-    });
+    updateBrowserFile(binary, outputDir);
+    promises.push(
+        FileManager.downloadFile(binary, outputDir, proxy, ignoreSSL)
+            .then<void>((downloaded: boolean) => {
+              if (!downloaded) {
+                logger.info(
+                    binary.name + ': file exists ' +
+                    path.resolve(outputDir, binary.filename(Config.osType(), Config.osArch())));
+                logger.info(binary.name + ': ' + binary.versionCustom + ' up to date');
+              }
+            }));
   }
   if (chrome) {
     let binary = binaries[ChromeDriver.id];
-    updateBinary(binary, outputDir, proxy, ignoreSSL);
+    updateBrowserFile(binary, outputDir);
+    promises.push(updateBinary(binary, outputDir, proxy, ignoreSSL));
   }
   if (gecko) {
     let binary = binaries[GeckoDriver.id];
-    updateBinary(binary, outputDir, proxy, ignoreSSL);
+    updateBrowserFile(binary, outputDir);
+    promises.push(updateBinary(binary, outputDir, proxy, ignoreSSL));
   }
   if (ie) {
     let binary = binaries[IEDriver.id];
     binary.arch = Config.osArch();  // Win32 or x64
-    updateBinary(binary, outputDir, proxy, ignoreSSL);
+    updateBrowserFile(binary, outputDir);
+    promises.push(updateBinary(binary, outputDir, proxy, ignoreSSL));
   }
   if (ie32) {
     let binary = binaries[IEDriver.id];
     binary.arch = 'Win32';
-    updateBinary(binary, outputDir, proxy, ignoreSSL);
+    updateBrowserFile(binary, outputDir);
+    promises.push(updateBinary(binary, outputDir, proxy, ignoreSSL));
   }
   if (android) {
     let binary = binaries[AndroidSDK.id];
     let sdk_path = path.resolve(outputDir, binary.executableFilename(Config.osType()));
     let oldAVDList: string;
 
-    q.nfcall(fs.readFile, path.resolve(sdk_path, 'available_avds.json'))
-        .then(
-            (oldAVDs: string) => {
-              oldAVDList = oldAVDs;
-            },
-            () => {
-              oldAVDList = '[]';
-            })
-        .then(() => {
-          return updateBinary(binary, outputDir, proxy, ignoreSSL);
-        })
-        .then(() => {
-          initializeAndroid(
-              path.resolve(outputDir, binary.executableFilename(Config.osType())),
-              android_api_levels, android_architectures, android_platforms, android_accept_licenses,
-              binaries[AndroidSDK.id].versionCustom, JSON.parse(oldAVDList), logger, verbose);
-        })
-        .done();
+    promises.push(q.nfcall(fs.readFile, path.resolve(sdk_path, 'available_avds.json'))
+                      .then(
+                          (oldAVDs: string) => {
+                            oldAVDList = oldAVDs;
+                          },
+                          () => {
+                            oldAVDList = '[]';
+                          })
+                      .then(() => {
+                        return updateBinary(binary, outputDir, proxy, ignoreSSL);
+                      })
+                      .then<void>(() => {
+                        initializeAndroid(
+                            path.resolve(outputDir, binary.executableFilename(Config.osType())),
+                            android_api_levels, android_architectures, android_platforms,
+                            android_accept_licenses, binaries[AndroidSDK.id].versionCustom,
+                            JSON.parse(oldAVDList), logger, verbose);
+                      }));
   }
   if (ios) {
     checkIOS(logger);
@@ -175,6 +192,10 @@ function update(options: Options): void {
   if (android || ios) {
     installAppium(binaries[Appium.id], outputDir);
   }
+
+  writeBrowserFile(outputDir);
+
+  return Promise.all(promises).then(() => {});
 }
 
 function updateBinary(
@@ -193,7 +214,7 @@ function updateBinary(
               path.resolve(outputDir, binary.filename(Config.osType(), Config.osArch())));
           let fileName = binary.filename(Config.osType(), Config.osArch());
           unzip(binary, outputDir, fileName);
-          logger.info(binary.name + ': v' + binary.versionCustom + ' up to date');
+          logger.info(binary.name + ': ' + binary.versionCustom + ' up to date');
         }
       });
 }
@@ -250,4 +271,47 @@ function installAppium(binary: Binary, outputDir: string): void {
   fs.writeFileSync(
       path.resolve(folder, 'package.json'), JSON.stringify({scripts: {appium: 'appium'}}));
   spawn('npm', ['install', 'appium@' + binary.version()], null, {cwd: folder});
+}
+
+interface BinaryPath {
+  last?: string, all?: string[]
+}
+
+interface BrowserFile {
+  chrome?: BinaryPath, standalone?: BinaryPath, gecko?: BinaryPath, iedriver?: BinaryPath
+}
+
+function updateBrowserFile<T extends Binary>(binary: T, outputDir: string) {
+  let currentDownload = path.resolve(outputDir, binary.executableFilename(Config.osType()));
+
+  // if browserFile[id] exists, we should update it
+  if ((browserFile as any)[binary.id()]) {
+    let binaryPath: BinaryPath = (browserFile as any)[binary.id()];
+    if (binaryPath.last === currentDownload) {
+      return;
+    } else {
+      binaryPath.last = currentDownload;
+      for (let bin of binaryPath.all) {
+        if (bin === currentDownload) {
+          return;
+        }
+      }
+      binaryPath.all.push(currentDownload);
+    }
+  } else {
+    // The browserFile[id] does not exist / has not been downloaded previously.
+    // We should create the entry.
+    let binaryPath: BinaryPath = {last: currentDownload, all: [currentDownload]};
+    (browserFile as any)[binary.id()] = binaryPath;
+  }
+}
+
+function writeBrowserFile(outputDir: string) {
+  let filePath = path.resolve(outputDir, 'update-config.json');
+  fs.writeFileSync(filePath, JSON.stringify(browserFile));
+}
+
+// for testing
+export function clearBrowserFile() {
+  browserFile = {};
 }

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -85,7 +85,7 @@ function update(options: Options): Promise<void> {
   if (options[Opt.IOS]) {
     ios = options[Opt.IOS].getBoolean();
   }
-  let outputDir = Config.getSeleniumDir();
+  let outputDir = options[Opt.OUT_DIR].getString();
 
   try {
     browserFile =

--- a/lib/files/downloader.ts
+++ b/lib/files/downloader.ts
@@ -70,8 +70,6 @@ export class Downloader {
   static getFile(
       binary: Binary, fileUrl: string, fileName: string, outputDir: string, contentLength: number,
       opt_proxy?: string, opt_ignoreSSL?: boolean, callback?: Function): Promise<any> {
-    // logger.info('curl -o ' + outputDir + '/' + fileName + ' ' + fileUrl);
-    // let contentLength = 0;
     let filePath = path.resolve(outputDir, fileName);
     let file: any;
 
@@ -90,8 +88,8 @@ export class Downloader {
 
     if (opt_proxy) {
       options.proxy = Downloader.resolveProxy_(fileUrl, opt_proxy);
-      if (options.url.indexOf('https://') === 0) {
-        options.url = options.url.replace('https://', 'http://');
+      if (url.parse(options.url).protocol === 'https:') {
+        options.url = options.url.replace('https:', 'http:');
       }
     }
 
@@ -108,6 +106,17 @@ export class Downloader {
                    response.destroy();
                    resolve(false);
                  } else {
+                   if (opt_proxy) {
+                     let pathUrl = url.parse(options.url).path;
+                     let host = url.parse(options.url).host;
+                     let newFileUrl = url.resolve(opt_proxy, pathUrl);
+                     logger.info(
+                         'curl -o ' + outputDir + '/' + fileName + ' \'' + newFileUrl +
+                         '\' -H \'host:' + host + '\'');
+                   } else {
+                     logger.info('curl -o ' + outputDir + '/' + fileName + ' ' + fileUrl);
+                   }
+
                    // only pipe if the headers are different length
                    file = fs.createWriteStream(filePath);
                    req.pipe(file);

--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -187,7 +187,7 @@ export class FileManager {
           let v = versions[index];
           if (v === version) {
             contentLength = fs.statSync(filePath).size;
-            Downloader
+            return Downloader
                 .getFile(
                     binary, fileUrl, fileName, outputDir, contentLength, opt_proxy, opt_ignoreSSL,
                     callback)

--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as q from 'q';
-import * as rimraf from 'rimraf';
 
 import {Binary, BinaryMap, ChromeDriver, IEDriver, AndroidSDK, Appium, StandAlone, OS} from
 '../binaries';
@@ -197,17 +196,17 @@ export class FileManager {
                 });
           }
         }
-      } else {
-        // We have not downloaded it before, or the version does not exist. Use the default content
-        // length of zero and download the file.
-        Downloader
-            .getFile(
-                binary, fileUrl, fileName, outputDir, contentLength, opt_proxy, opt_ignoreSSL,
-                callback)
-            .then(downloaded => {
-              resolve(downloaded);
-            });
       }
+      // We have not downloaded it before, or the version does not exist. Use the default content
+      // length of zero and download the file.
+      Downloader
+          .getFile(
+              binary, fileUrl, fileName, outputDir, contentLength, opt_proxy, opt_ignoreSSL,
+              callback)
+          .then(downloaded => {
+            resolve(downloaded);
+          });
+
     });
   }
 
@@ -238,6 +237,14 @@ export class FileManager {
           logger.info('removed ' + file);
         }
       }
-    })
+    });
+
+    let updateConfig = path.resolve(outputDir, 'update-config.json');
+    try {
+      fs.unlinkSync(updateConfig);
+      logger.info('removed update-config.json');
+    } catch (e) {
+      return;
+    }
   }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,7 +5,6 @@ import * as path from 'path';
 
 import {Config} from './config';
 
-
 function spawnFactory(sync: false):
     (cmd: string, args: string[], stdio?: any, opts?: child_process.SpawnOptions) =>
         child_process.ChildProcess;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "gulp format",
     "prepublish": "gulp prepublish",
     "test": "gulp test",
-    "test:unit": "gulp test:unit",
+    "test_unit": "gulp test:unit",
     "test_travis": "gulp test:headless"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "format": "gulp format",
     "prepublish": "gulp prepublish",
     "test": "gulp test",
+    "test:unit": "gulp test:unit",
     "test_travis": "gulp test:headless"
   },
   "keywords": [

--- a/spec/cmds/update_spec.ts
+++ b/spec/cmds/update_spec.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as process from 'process';
+import * as rimraf from 'rimraf';
+
+import {Logger, WriteTo} from '../../lib/cli/logger';
+import {clearBrowserFile, program} from '../../lib/cmds/update';
+import {Config} from '../../lib/config';
+
+interface Argv {
+  [key: string]: any;
+}
+let argv: Argv = {};
+
+describe('update', () => {
+  describe('for update-config.json', () => {
+    let tmpDir = '';
+    beforeEach(() => {
+      Logger.writeTo = WriteTo.NONE;
+      tmpDir = path.resolve(process.cwd(), 'selenium_test');
+      try {
+        // if the folder does not exist, it will throw an error on statSync
+        if (fs.statSync(tmpDir).isDirectory()) {
+          rimraf.sync(tmpDir);
+        }
+      } catch (err) {
+        // do nothing, the directory does not exist
+      }
+      fs.mkdirSync(tmpDir);
+    });
+
+    afterEach(() => {
+      rimraf.sync(tmpDir);
+      clearBrowserFile();
+    });
+
+    it('should create a file for chrome', (done) => {
+      Config.osType_ = 'Linux';
+      Config.osArch_ = 'x64';
+      argv = {
+        '_': ['update'],
+        'versions': {'chrome': '2.20'},
+        'standalone': false,
+        'gecko': false,
+        'out_dir': tmpDir
+      };
+      program.run(JSON.parse(JSON.stringify(argv)))
+          .then(() => {
+            let updateConfig =
+                fs.readFileSync(path.resolve(tmpDir, 'update-config.json')).toString();
+            let updateObj = JSON.parse(updateConfig);
+            expect(updateObj['chrome']['last']).toContain('chromedriver_2.20');
+            expect(updateObj['chrome']['all'].length).toEqual(1);
+            expect(updateObj['chrome']['last']).toEqual(updateObj['chrome']['all'][0]);
+            expect(updateObj['standalone']).toBeUndefined();
+            expect(updateObj['ie']).toBeUndefined();
+            done();
+          })
+          .catch((err: Error) => {done.fail()});
+    });
+
+    it('should create a file for standalone', (done) => {
+      Config.osType_ = 'Linux';
+      Config.osArch_ = 'x64';
+      argv = {
+        '_': ['update'],
+        'versions': {'standalone': '2.53.1'},
+        'chrome': false,
+        'gecko': false,
+        'out_dir': tmpDir
+      };
+      program.run(JSON.parse(JSON.stringify(argv)))
+          .then(() => {
+            let updateConfig =
+                fs.readFileSync(path.resolve(tmpDir, 'update-config.json')).toString();
+            let updateObj = JSON.parse(updateConfig);
+            expect(updateObj['standalone']['last']).toContain('standalone-2.53.1.jar');
+            expect(updateObj['standalone']['all'].length).toEqual(1);
+            expect(updateObj['standalone']['last']).toEqual(updateObj['standalone']['all'][0]);
+            expect(updateObj['chrome']).toBeUndefined();
+            expect(updateObj['ie']).toBeUndefined();
+            done();
+          })
+          .catch((err: Error) => {done.fail()});
+    });
+
+    // TODO(cnishina): Create a test for Windows for IE driver. This will require rewriting
+    // how programs get configurations.
+  });
+});

--- a/spec/cmds/update_spec.ts
+++ b/spec/cmds/update_spec.ts
@@ -17,7 +17,7 @@ describe('update', () => {
     let tmpDir = '';
     beforeEach(() => {
       Logger.writeTo = WriteTo.NONE;
-      tmpDir = path.resolve(process.cwd(), 'selenium_test');
+      tmpDir = path.resolve('selenium_test');
       try {
         // if the folder does not exist, it will throw an error on statSync
         if (fs.statSync(tmpDir).isDirectory()) {

--- a/spec/files/downloader_spec.ts
+++ b/spec/files/downloader_spec.ts
@@ -82,9 +82,22 @@ describe('downloader', () => {
     let fileUrl =
         'https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.0.jar';
     let fileName = 'foobar.jar';
-    let outputDir = Config.getSeleniumDir();
+    let outputDir = path.resolve(process.cwd(), 'selenium_test');
     let actualContentLength = 22138949;
     let contentLength: number;
+
+    beforeEach(() => {
+      outputDir = path.resolve(process.cwd(), 'selenium_test');
+      try {
+        // if the folder does not exist, it will throw an error on statSync
+        if (fs.statSync(outputDir).isDirectory()) {
+          rimraf.sync(outputDir);
+        }
+      } catch (err) {
+        // do nothing, the directory does not exist
+      }
+      fs.mkdirSync(outputDir);
+    });
 
     it('should download a file with mismatch content length', (done) => {
       contentLength = 0;

--- a/spec/files/downloader_spec.ts
+++ b/spec/files/downloader_spec.ts
@@ -87,7 +87,6 @@ describe('downloader', () => {
     let contentLength: number;
 
     beforeEach(() => {
-      outputDir = path.resolve(process.cwd(), 'selenium_test');
       try {
         // if the folder does not exist, it will throw an error on statSync
         if (fs.statSync(outputDir).isDirectory()) {

--- a/spec/files/downloader_spec.ts
+++ b/spec/files/downloader_spec.ts
@@ -82,7 +82,7 @@ describe('downloader', () => {
     let fileUrl =
         'https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.0.jar';
     let fileName = 'foobar.jar';
-    let outputDir = path.resolve(process.cwd(), 'selenium_test');
+    let outputDir = path.resolve('selenium_test');
     let actualContentLength = 22138949;
     let contentLength: number;
 


### PR DESCRIPTION
This feature will help directConnect users for Protractor. The file
will keep track of the last binary version as well as all other
binaries downloaded.

The file will be created in the output directory. By default this is
`selenium/update-config.json`

  ```
  webdriver-manager update --versions.chrome=2.20 --standalone=false
  --gecko=false
  ```

  file created:
  ```
  {
    "chrome": {
      "last": "/opt/src/webdriver-manager/selenium/chromedriver_2.20",
      "all": ["/opt/src/webdriver-manager/selenium/chromedriver_2.20"]
    }
  }
  ```

  then the user wants to use 2.25:

  ```
  webdriver-manager update --versions.chrome=2.25 --standalone=false
  --gecko=false

  ```

  file created:
  ```
  {
    "chrome": {
      "last": "/opt/src/webdriver-manager/selenium/chromedriver_2.25",
      "all": ["/opt/src/webdriver-manager/selenium/chromedriver_2.20",
              "/opt/src/webdriver-manager/selenium/chromedriver_2.25"]
    }
  }
  ```