### PR TITLE
`httpHeadContentLength`: Destroy the request after receiving the header

### DIFF
--- a/lib/files/downloader.ts
+++ b/lib/files/downloader.ts
@@ -104,6 +104,7 @@ export class Downloader {
         let contentLength = response.headers['content-length'];
         deferred.resolve(contentLength);
       }
+      response.destroy();
     });
     return deferred.promise;
   }


### PR DESCRIPTION
… Otherwise we won’t terminate until the whole file was downloaded, even though we don’t need it.

This patch reduces the time required for `webdriver-manager update` on an up-to-date installation from more than 5 seconds to less than 2 seconds on my machine (when updating `standalone`, `gecko` and `chrome`).

Btw: It's still wasteful to run `httpHeadContentLength` and then `downloadBinary` in case we're outdated – since the former already starts downloading. It might be better to start the request, wait for the headers and then either continue or abort – instead of always throwing away the first request and then starting over again.