### PR TITLE
feat(quiet/verbose): add `--quiet` and `--verbose` flags to control t…

### DIFF
--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -34,6 +34,8 @@ export const AVD_USE_SNAPSHOTS = 'avd-use-snapshots';
 export const STARTED_SIGNIFIER = 'started-signifier';
 export const SIGNAL_VIA_IPC = 'signal-via-ipc';
 export const DETACH = 'detach';
+export const QUIET = 'quiet';
+export const VERBOSE = 'verbose';
 
 /**
  * The options used by the commands.
@@ -108,5 +110,7 @@ opts[DETACH] = new Option(
     DETACH,
     'Once the selenium server is up and running, return control to the parent process and continue running the server in the background.',
     'boolean', false);
+opts[VERBOSE] = new Option(VERBOSE, 'Extra console output', 'boolean', false);
+opts[QUIET] = new Option(QUIET, 'Minimal console output', 'boolean', false);
 
 export var Opts = opts;

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -22,6 +22,7 @@ let prog = new Program()
                .command('update', 'install or update selected binaries')
                .action(update)
                .addOption(Opts[Opt.OUT_DIR])
+               .addOption(Opts[Opt.VERBOSE])
                .addOption(Opts[Opt.IGNORE_SSL])
                .addOption(Opts[Opt.PROXY])
                .addOption(Opts[Opt.ALTERNATE_CDN])
@@ -98,6 +99,7 @@ function update(options: Options): void {
   }
   let ignoreSSL = options[Opt.IGNORE_SSL].getBoolean();
   let proxy = options[Opt.PROXY].getString();
+  let verbose = options[Opt.VERBOSE].getBoolean();
 
   // setup versions for binaries
   let binaries = FileManager.setupBinaries(options[Opt.ALTERNATE_CDN].getString());
@@ -166,7 +168,7 @@ function update(options: Options): void {
           initializeAndroid(
               path.resolve(outputDir, binary.executableFilename(os.type())), android_api_levels,
               android_architectures, android_platforms, android_accept_licenses,
-              binaries[AndroidSDK.id].versionCustom, JSON.parse(oldAVDList), logger);
+              binaries[AndroidSDK.id].versionCustom, JSON.parse(oldAVDList), logger, verbose);
         })
         .done();
   }


### PR DESCRIPTION
…he level of output

I added the `--quiet` flag for cases like:
`webdriver-manager start --detach; ./tests.sh; webdriver-manager shutdown`
where currently the selenium server output will get mixed in with other output.

I also added the `--verbose` flag for `webdriver-manager update` in case you *really* wanted to
see all the output which gets eaten by using `--android-accept-licenses`.