### PR TITLE
chore(downloader): replace workflow with a single request

### DIFF
--- a/spec/files/downloader_spec.ts
+++ b/spec/files/downloader_spec.ts
@@ -1,3 +1,7 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as rimraf from 'rimraf';
+
 import {Config} from '../../lib/config';
 import {Downloader} from '../../lib/files';
 
@@ -71,6 +75,51 @@ describe('downloader', () => {
         let proxy = Downloader.resolveProxy_(fileUrlHttp);
         expect(proxy).toBeUndefined();
       });
+    });
+  });
+
+  describe('get file', () => {
+    let fileUrl =
+        'https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.0.jar';
+    let fileName = 'foobar.jar';
+    let outputDir = Config.getSeleniumDir();
+    let actualContentLength = 22138949;
+    let contentLength: number;
+
+    it('should download a file with mismatch content length', (done) => {
+      contentLength = 0;
+      Downloader.getFile(null, fileUrl, fileName, outputDir, contentLength)
+          .then(result => {
+            expect(result).toBeTruthy();
+            let file = path.resolve(outputDir, fileName);
+            let stat = fs.statSync(file);
+            expect(stat.size).toEqual(actualContentLength);
+            rimraf.sync(file);
+            done();
+          })
+          .catch(error => {
+            console.log(error);
+            done.fail();
+          });
+    });
+
+    it('should not download a file if the content lengths match', (done) => {
+      contentLength = actualContentLength;
+      Downloader.getFile(null, fileUrl, fileName, outputDir, contentLength)
+          .then(result => {
+            expect(result).not.toBeTruthy();
+            let file = path.resolve(outputDir, fileName);
+            try {
+              let access = fs.accessSync(file);
+            } catch (err) {
+              (err as any).code === 'ENOENT'
+            }
+            done();
+          })
+          .catch(error => {
+            console.log(error);
+            done.fail();
+          });
     });
   });
 });

--- a/spec/files/fileManager_spec.ts
+++ b/spec/files/fileManager_spec.ts
@@ -265,4 +265,6 @@ describe('file manager', () => {
       }
     }
   });
+
+  // TODO(cnishina): download binaries for each os type / arch combination
 });


### PR DESCRIPTION
- add method to downloader to getFile
- add method to file manager to use new downloader getFile
- rewrite updateBinary function to use new file manager method
- add a couple of unit tests around downloader getFile
- use es6 promises, change travis to use node 6 minimum
- remove old method to request file in file manager and downloader