### PR TITLE
chore(es6): allow to use es6 promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - "4"
-  - "5"
+  - "6"
+  - "7"
 
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "author": "Craig Nishina <craig.nishina@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@types/es6-promise": "0.0.32",
     "adm-zip": "^0.4.7",
     "chalk": "^1.1.1",
     "del": "^2.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
@@ -10,7 +10,7 @@
     "outDir": "built/",
     "types": [
       "adm-zip", "chalk", "glob", "jasmine", "minimist",
-      "node", "q", "request", "rimraf", "semver", "es6-promise"
+      "node", "q", "request", "rimraf", "semver"
     ]
   },
   "exclude": [


### PR DESCRIPTION
- with node 6 on LTS, we can update the tsconfig to es6
- update travis tests to use node 6 and 7