### PR TITLE
fix(start): wait for emulated android to really be ready before signaling

### DIFF
--- a/lib/binaries/android_sdk.ts
+++ b/lib/binaries/android_sdk.ts
@@ -39,6 +39,11 @@ export class AndroidSDK extends Binary {
   static DEFAULT_API_LEVELS = '24';
   static DEFAULT_ARCHITECTURES = getAndroidArch();
   static DEFAULT_PLATFORMS = 'google_apis';
+  static VERSIONS: {[api_level: number]: string} = {
+    // Before 24 is not supported
+    24: '7.0',
+    25: '7.1'
+  }
 
   constructor(alternateCDN?: string) {
     super(alternateCDN || Config.cdnUrls().android);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,7 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
 
 import {Config} from './config';
 
@@ -38,3 +40,92 @@ function spawnFactory(sync: boolean):
 
 export let spawn = spawnFactory(false);
 export let spawnSync = spawnFactory(true);
+
+export function request(
+    method: string, port: string, path: string, timeout?: number, data?: any): Promise<string> {
+  let headers: {[key: string]: string} = {};
+  let hasContent = data && ((method == 'POST') || (method == 'PUT'));
+  if (hasContent) {
+    data = data ? JSON.stringify(data) : '';
+    headers['Content-Length'] = data.length;
+    headers['Content-Type'] = 'application/json;charset=UTF-8';
+  }
+  return new Promise<string>((resolve, reject) => {
+    let unexpectedEnd = () => {
+      reject({code: 'UNKNOWN', message: 'Request ended unexpectedly'});
+    };
+    let req = http.request(
+        {port: parseInt(port), method: method, path: path, headers: headers}, (res) => {
+          req.removeListener('end', unexpectedEnd);
+          if (res.statusCode !== 200) {
+            reject({code: res.statusCode, message: res.statusMessage});
+          } else {
+            let buffer: (string|Buffer)[] = [];
+            res.on('data', buffer.push.bind(buffer));
+            res.on('end', () => {
+              resolve(buffer.join('').replace(/\0/g, ''));
+            });
+          }
+        });
+
+    if (timeout) {
+      req.setTimeout(timeout, () => {
+        reject({code: 'TIMEOUT', message: 'Request timed out'});
+      });
+    }
+    req.on('error', reject);
+    req.on('end', unexpectedEnd);
+
+    if (hasContent) {
+      req.write(data as string);
+    }
+
+    req.end();
+  });
+}
+
+export function adb(
+    sdkPath: string, port: number, command: string, timeout: number,
+    args?: string[]): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let child = spawn(
+        path.resolve(sdkPath, 'platform-tools', 'adb'),
+        ['-s', 'emulator-' + port, command].concat(args || []), 'pipe');
+    let done = false;
+    let buffer: (string|Buffer)[] = [];
+    child.stdout.on('data', buffer.push.bind(buffer));
+    child.on('error', (err: Error) => {
+      if (!done) {
+        done = true;
+        reject(err);
+      }
+    });
+    child.on('exit', (code: number, signal: string) => {
+      if (!done) {
+        done = true;
+        if (code === 0) {
+          resolve(buffer.join(''));
+        } else {
+          reject({
+            code: code,
+            message: 'abd command "' + command + '" ' +
+                (signal ? 'received signal ' + signal : 'returned with a non-zero exit code') +
+                'for emulator-' + port
+          });
+        }
+      }
+    });
+    if (timeout) {
+      setTimeout(() => {
+        if (!done) {
+          done = true;
+          child.kill();
+          reject({
+            code: 'TIMEOUT',
+            message: 'adb command "' + command + '" timed out for emulator-' + port
+          });
+        }
+      }, timeout);
+    }
+  });
+}


### PR DESCRIPTION
Before, we were just waiting for the emulator to be running, rather than waiting for the OS to be
booted up and ready to instance chrome.

While I was doing that I moved some stuff into `lib/utils.ts` since I felt like too much of
`lib/cmds/start.ts` was being devoted to this one feature.

Additionally, `--started-signifier` wasn't sending anything to the console, so I fixed that too (see https://github.com/angular/webdriver-manager/issues/166)