### PR TITLE
feat(shutdown): do not error if you try to shutdown a server which is already off

### DIFF
--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -36,6 +36,7 @@ export const SIGNAL_VIA_IPC = 'signal-via-ipc';
 export const DETACH = 'detach';
 export const QUIET = 'quiet';
 export const VERBOSE = 'verbose';
+export const ALREADY_OFF_ERROR = 'already-off-error';
 
 /**
  * The options used by the commands.
@@ -112,5 +113,9 @@ opts[DETACH] = new Option(
     'boolean', false);
 opts[VERBOSE] = new Option(VERBOSE, 'Extra console output', 'boolean', false);
 opts[QUIET] = new Option(QUIET, 'Minimal console output', 'boolean', false);
+opts[ALREADY_OFF_ERROR] = new Option(
+    ALREADY_OFF_ERROR,
+    'Normally if you try to shut down a selenium which is not running, you will get a warning.  This turns it into an error',
+    'boolean', false);
 
 export var Opts = opts;


### PR DESCRIPTION
When scripting, you might want to defensively run a `shutdown` command.  If the shutdown fails
because the server is already off, you don't care.  If it fails for another reason, you do care.
So I made trying to shutdown a server which is already off just a warning.  I added a flag in case
you want the old behavior though.