### PR TITLE
feat(android): match android arch to os.arch

### DIFF
--- a/lib/binaries/android_sdk.ts
+++ b/lib/binaries/android_sdk.ts
@@ -6,6 +6,26 @@ import {spawnSync} from '../utils';
 
 import {Binary, OS} from './binary';
 
+function getAndroidArch(): string {
+  switch (Config.osArch()) {
+    case 'arm':
+      return 'armeabi-v7a';
+    case 'arm64':
+      return 'arm64-v8a';
+    case 'x86':
+    case 'x32':
+    case 'ia32':
+    case 'ppc':
+      return 'x86';
+    case 'x86-64':
+    case 'x64':
+    case 'ia64':
+    case 'ppc64':
+      return 'x86_64';
+    default:
+      return Config.osArch();
+  }
+}
 
 /**
  * The android sdk binary.
@@ -17,7 +37,7 @@ export class AndroidSDK extends Binary {
   static isDefault = false;
   static shortName = ['android'];
   static DEFAULT_API_LEVELS = '24';
-  static DEFAULT_ARCHITECTURES = 'x86_64';
+  static DEFAULT_ARCHITECTURES = getAndroidArch();
   static DEFAULT_PLATFORMS = 'google_apis';
 
   constructor(alternateCDN?: string) {

--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -26,7 +26,7 @@ export const VERSIONS_APPIUM = 'versions.appium';
 export const CHROME_LOGS = 'chrome_logs';
 export const LOGGING = 'logging';
 export const ANDROID_API_LEVELS = 'android-api-levels';
-export const ANDROID_ARCHITECTURES = 'android-architectures';
+export const ANDROID_ARCHITECTURES = 'android-archs';
 export const ANDROID_PLATFORMS = 'android-platorms';
 export const ANDROID_ACCEPT_LICENSES = 'android-accept-licenses';
 export const AVDS = 'avds';
@@ -83,8 +83,9 @@ opts[ANDROID_API_LEVELS] = new Option(
     ANDROID_API_LEVELS, 'Which versions of the android API you want to emulate', 'string',
     AndroidSDK.DEFAULT_API_LEVELS);
 opts[ANDROID_ARCHITECTURES] = new Option(
-    ANDROID_ARCHITECTURES, 'Which architectures you want to use in android emulation', 'string',
-    AndroidSDK.DEFAULT_ARCHITECTURES);
+    ANDROID_ARCHITECTURES,
+    'Which architectures you want to use in android emulation.  By default it will try to match os.arch()',
+    'string', AndroidSDK.DEFAULT_ARCHITECTURES);
 opts[ANDROID_PLATFORMS] = new Option(
     ANDROID_PLATFORMS, 'Which platforms you want to use in android emulation', 'string',
     AndroidSDK.DEFAULT_PLATFORMS);

--- a/mobile.md
+++ b/mobile.md
@@ -16,13 +16,13 @@ android device running version 24 on x86-64.  If you need a different device, yo
 `--android-api-levels` and `--android-abis` flags.  So you might run a command like this:
 
 ```
-webdriver-manager update --android --android-api-levels 24 --android-abis armeabi-v7a
+webdriver-manager update --android --android-api-levels 24 --android-archs armeabi-v7a
 ```
 
 Valid values for the `--android-api-levels` flag are: `24` and `25`.  You *can* specify a lower
 API level, but the virtual device create will not have Chrome installed.
 
-Valid values for the `--android-architectures` flag are: 
+Valid values for the `--android-archs` flag are: 
 
 * `x86`
 * `x86_64`
@@ -31,9 +31,9 @@ Valid values for the `--android-architectures` flag are:
 * `mips`
 
 Note that we always use the `google_apis/*` ABIs, since only those versions comes with chrome.  So
-if you specify `--android-architectures x86_64`, this tool will use the ABI `google_apis/x86_64`.
-If you wish to use a different platform (i.e. `android-wear`, `android-tv` or `default`), you can
-do so with the `--android-platforms` flag.  But only the `google_apis` version comes with Chrome.
+if you specify `--android-archs x86_64`, this tool will use the ABI `google_apis/x86_64`.  If you
+wish to use a different platform (i.e. `android-wear`, `android-tv` or `default`), you can do so
+with the `--android-platforms` flag.  But only the `google_apis` version comes with Chrome.
 
 
 As a practical matter, if you don't want to manually accept the license agreements, you can use


### PR DESCRIPTION
The default was x86-64, but x86 cannot be emulated on ARM.  This makes more sense