### PR TITLE
fix(iedriver): if downloading x64, use x64 version on start command

### DIFF
--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -130,7 +130,6 @@ function start(options: Options) {
     // https://bugs.openjdk.java.net/browse/JDK-6202721
     args.push('-Djava.security.egd=file:///dev/./urandom');
   }
-
   if (options[Opt.LOGGING].getString()) {
     if (path.isAbsolute(options[Opt.LOGGING].getString())) {
       loggingFile = options[Opt.LOGGING].getString();
@@ -154,14 +153,14 @@ function start(options: Options) {
         path.resolve(outputDir, binaries[GeckoDriver.id].executableFilename(osType)));
   }
   if (downloadedBinaries[IEDriver.id] != null) {
-    if (options[Opt.IE32]) {
+    if (options[Opt.IE32].getBoolean()) {
       binaries[IEDriver.id].arch = 'Win32';
     }
     args.push(
         '-Dwebdriver.ie.driver=' +
         path.resolve(outputDir, binaries[IEDriver.id].executableFilename(osType)));
   }
-  if (options[Opt.EDGE]) {
+  if (options[Opt.EDGE] && options[Opt.EDGE].getString()) {
     // validate that the file exists prior to adding it to args
     try {
       let edgeFile = options[Opt.EDGE].getString();


### PR DESCRIPTION
- clang formatting

closes #147