### PR TITLE
feat(gecko): Improve error message when Github api limit reached.

### DIFF
--- a/lib/binaries/config_source.ts
+++ b/lib/binaries/config_source.ts
@@ -156,8 +156,10 @@ export abstract class GithubApiConfigSource extends JsonConfigSource {
             resolve(output);
           });
 
+        } else if (response.statusCode == 403 && response.headers['x-ratelimit-remaining'] == 0) {
+          reject(new Error('Failed to make Github request, rate limit reached.'));
         } else {
-          reject(new Error('response status code is not 200'));
+          reject(new Error('response status code is not 200.  It was ' + response.statusCode));
         }
       })
     });


### PR DESCRIPTION
When the Github API limit is reached, the error message now directly informs
the user.  Also, when any other failure occurs the status code is reported.

This should hopefully give more info for issue #216.