### PR TITLE
fix(ignoressl): pass option to both binary and config source

### DIFF
--- a/lib/binaries/binary.ts
+++ b/lib/binaries/binary.ts
@@ -89,16 +89,19 @@ export abstract class Binary {
   getUrl(version?: string, opt_proxy?: string, opt_ignoreSSL?: boolean): Promise<BinaryUrl> {
     this.opt_proxy = opt_proxy == undefined ? this.opt_proxy : opt_proxy;
     this.opt_ignoreSSL = opt_ignoreSSL == undefined ? this.opt_ignoreSSL : opt_ignoreSSL;
+    if (this.configSource) {
+      this.configSource.opt_proxy = this.opt_proxy;
+      this.configSource.opt_ignoreSSL = this.opt_ignoreSSL;
+    }
     if (this.alternativeDownloadUrl != null) {
       return Promise.resolve({url: '', version: ''});
     } else {
       return this.getVersionList().then(() => {
         version = version || Config.binaryVersions()[this.id()];
-        return this.configSource.getUrl(version, this.opt_proxy, this.opt_ignoreSSL)
-            .then(binaryUrl => {
-              this.versionCustom = binaryUrl.version;
-              return {url: binaryUrl.url, version: binaryUrl.version};
-            });
+        return this.configSource.getUrl(version).then(binaryUrl => {
+          this.versionCustom = binaryUrl.version;
+          return {url: binaryUrl.url, version: binaryUrl.version};
+        });
       });
     }
   }

--- a/lib/binaries/chrome_xml.ts
+++ b/lib/binaries/chrome_xml.ts
@@ -10,9 +10,7 @@ export class ChromeXml extends XmlConfigSource {
     super('chrome', Config.cdnUrls()['chrome']);
   }
 
-  getUrl(version: string, opt_proxy?: string, opt_ignoreSSL?: boolean): Promise<BinaryUrl> {
-    this.opt_proxy = opt_proxy == undefined ? this.opt_proxy : opt_proxy;
-    this.opt_ignoreSSL = opt_ignoreSSL == undefined ? this.opt_ignoreSSL : opt_ignoreSSL;
+  getUrl(version: string): Promise<BinaryUrl> {
     if (version === 'latest') {
       return this.getLatestChromeDriverVersion();
     } else {

--- a/lib/binaries/config_source.ts
+++ b/lib/binaries/config_source.ts
@@ -14,8 +14,7 @@ export abstract class ConfigSource {
   opt_ignoreSSL: boolean;
   opt_proxy: string;
 
-  abstract getUrl(version: string, opt_proxy?: string, opt_ignoreSSL?: boolean):
-      Promise<{url: string, version: string}>;
+  abstract getUrl(version: string): Promise<{url: string, version: string}>;
   abstract getVersionList(): Promise<string[]>;
 }
 

--- a/lib/binaries/gecko_driver_github.ts
+++ b/lib/binaries/gecko_driver_github.ts
@@ -10,9 +10,7 @@ export class GeckoDriverGithub extends GithubApiConfigSource {
     super('gecko', 'https://api.github.com/repos/mozilla/geckodriver/releases');
   }
 
-  getUrl(version: string, opt_proxy?: string, opt_ignoreSSL?: boolean): Promise<BinaryUrl> {
-    this.opt_proxy = opt_proxy == undefined ? this.opt_proxy : opt_proxy;
-    this.opt_ignoreSSL = opt_ignoreSSL == undefined ? this.opt_ignoreSSL : opt_ignoreSSL;
+  getUrl(version: string): Promise<BinaryUrl> {
     if (version === 'latest') {
       return this.getLatestGeckoDriverVersion();
     } else {

--- a/lib/binaries/iedriver_xml.ts
+++ b/lib/binaries/iedriver_xml.ts
@@ -10,9 +10,7 @@ export class IEDriverXml extends XmlConfigSource {
     super('iedriver', Config.cdnUrls()['ie']);
   }
 
-  getUrl(version: string, opt_proxy?: string, opt_ignoreSSL?: boolean): Promise<BinaryUrl> {
-    this.opt_proxy = opt_proxy == undefined ? this.opt_proxy : opt_proxy;
-    this.opt_ignoreSSL = opt_ignoreSSL == undefined ? this.opt_ignoreSSL : opt_ignoreSSL;
+  getUrl(version: string): Promise<BinaryUrl> {
     if (version === 'latest') {
       return this.getLatestIEDriverVersion();
     } else {

--- a/lib/binaries/standalone_xml.ts
+++ b/lib/binaries/standalone_xml.ts
@@ -10,9 +10,7 @@ export class StandaloneXml extends XmlConfigSource {
     super('standalone', Config.cdnUrls()['selenium']);
   }
 
-  getUrl(version: string, opt_proxy?: string, opt_ignoreSSL?: boolean): Promise<BinaryUrl> {
-    this.opt_proxy = opt_proxy == undefined ? this.opt_proxy : opt_proxy;
-    this.opt_ignoreSSL = opt_ignoreSSL == undefined ? this.opt_ignoreSSL : opt_ignoreSSL;
+  getUrl(version: string): Promise<BinaryUrl> {
     if (version === 'latest') {
       return this.getLatestStandaloneVersion();
     } else {


### PR DESCRIPTION
In previous fix(#208), the option was not passing to config source.

closes #207.