### PR TITLE
refactor(binaries): remove proxy/ignoreSSL opts from binary/config source

### DIFF
--- a/lib/binaries/binary.ts
+++ b/lib/binaries/binary.ts
@@ -34,9 +34,7 @@ export abstract class Binary {
   //   the file from an alternative download URL.
   alternativeDownloadUrl: string;
 
-  cdn: string;             // The url host for XML reading or the base path to the url.
-  opt_ignoreSSL: boolean;  // An optional ignore ssl.
-  opt_proxy: string        // An optional proxy.
+  cdn: string;  // The url host for XML reading or the base path to the url.
 
   name: string;
   versionDefault: string;
@@ -83,16 +81,8 @@ export abstract class Binary {
    * If not, it will download from an existing url.
    *
    * @param {string} version The version we are looking for. This could also be 'latest'.
-   * @param {opt_proxy} string Option to get proxy URL.
-   * @param {opt_ignoreSSL} boolean Option to ignore SSL.
    */
-  getUrl(version?: string, opt_proxy?: string, opt_ignoreSSL?: boolean): Promise<BinaryUrl> {
-    this.opt_proxy = opt_proxy == undefined ? this.opt_proxy : opt_proxy;
-    this.opt_ignoreSSL = opt_ignoreSSL == undefined ? this.opt_ignoreSSL : opt_ignoreSSL;
-    if (this.configSource) {
-      this.configSource.opt_proxy = this.opt_proxy;
-      this.configSource.opt_ignoreSSL = this.opt_ignoreSSL;
-    }
+  getUrl(version?: string): Promise<BinaryUrl> {
     if (this.alternativeDownloadUrl != null) {
       return Promise.resolve({url: '', version: ''});
     } else {

--- a/lib/binaries/config_source.ts
+++ b/lib/binaries/config_source.ts
@@ -11,8 +11,6 @@ export abstract class ConfigSource {
   ostype = Config.osType();
   osarch = Config.osArch();
   out_dir: string = Config.getSeleniumDir();
-  opt_ignoreSSL: boolean;
-  opt_proxy: string;
 
   abstract getUrl(version: string): Promise<{url: string, version: string}>;
   abstract getVersionList(): Promise<string[]>;
@@ -64,8 +62,6 @@ export abstract class XmlConfigSource extends ConfigSource {
   private requestXml(): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       let options = HttpUtils.initOptions(this.xmlUrl);
-      options = HttpUtils.optionsSSL(options, this.opt_ignoreSSL);
-      options = HttpUtils.optionsProxy(options, this.xmlUrl, this.opt_proxy);
 
       let req = request(options);
       req.on('response', response => {
@@ -139,8 +135,6 @@ export abstract class GithubApiConfigSource extends JsonConfigSource {
   private requestJson(): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       let options = HttpUtils.initOptions(this.jsonUrl);
-      options = HttpUtils.optionsSSL(options, this.opt_ignoreSSL);
-      options = HttpUtils.optionsProxy(options, this.jsonUrl, this.opt_proxy);
       options = HttpUtils.optionsHeader(options, 'Host', 'api.github.com');
       options = HttpUtils.optionsHeader(options, 'User-Agent', 'request');
 

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -10,6 +10,7 @@ import {AndroidSDK, Appium, Binary, ChromeDriver, GeckoDriver, IEDriver, Standal
 import {Logger, Options, Program} from '../cli';
 import {Config} from '../config';
 import {Downloader, FileManager} from '../files';
+import {HttpUtils} from '../http_utils';
 import {spawn} from '../utils';
 
 import * as Opt from './';
@@ -111,6 +112,7 @@ function update(options: Options): Promise<void> {
   }
   let ignoreSSL = options[Opt.IGNORE_SSL].getBoolean();
   let proxy = options[Opt.PROXY].getString();
+  HttpUtils.assignOptions({ignoreSSL, proxy});
   let verbose = options[Opt.VERBOSE].getBoolean();
 
   // setup versions for binaries
@@ -131,7 +133,7 @@ function update(options: Options): Promise<void> {
   // permissions
   if (standalone) {
     let binary: Standalone = binaries[Standalone.id];
-    promises.push(FileManager.downloadFile(binary, outputDir, proxy, ignoreSSL)
+    promises.push(FileManager.downloadFile(binary, outputDir)
                       .then<void>((downloaded: boolean) => {
                         if (!downloaded) {
                           logger.info(
@@ -212,7 +214,7 @@ function updateBinary<T extends Binary>(
     binary: T, outputDir: string, proxy: string, ignoreSSL: boolean): Promise<void> {
   return FileManager
       .downloadFile(
-          binary, outputDir, proxy, ignoreSSL,
+          binary, outputDir,
           (binary: Binary, outputDir: string, fileName: string) => {
             unzip(binary, outputDir, fileName);
           })

--- a/lib/files/downloader.ts
+++ b/lib/files/downloader.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as q from 'q';
 import * as request from 'request';
-import * as url from 'url';
 
 import {Binary} from '../binaries';
 import {Logger} from '../cli';
@@ -24,20 +23,17 @@ export class Downloader {
    * @param outputDir The directory where files are downloaded and stored.
    * @param contentLength The content length of the existing file.
    * @param opt_proxy The proxy for downloading files.
-   * @param opt_ignoreSSL Should the downloader ignore SSL.
    * @param opt_callback Callback method to be executed after the file is downloaded.
    * @returns Promise<boolean> Resolves true = downloaded. Resolves false = not downloaded.
    *          Rejected with an error.
    */
   static getFile(
       binary: Binary, fileUrl: string, fileName: string, outputDir: string, contentLength: number,
-      opt_proxy?: string, opt_ignoreSSL?: boolean, callback?: Function): Promise<boolean> {
+      callback?: Function): Promise<boolean> {
     let filePath = path.resolve(outputDir, fileName);
     let file: any;
 
     let options = HttpUtils.initOptions(fileUrl);
-    options = HttpUtils.optionsSSL(options, opt_ignoreSSL);
-    options = HttpUtils.optionsProxy(options, fileUrl, opt_proxy);
 
     let req: request.Request = null;
     let resContentLength: number;
@@ -52,17 +48,6 @@ export class Downloader {
                    response.destroy();
                    resolve(false);
                  } else {
-                   if (opt_proxy) {
-                     let pathUrl = url.parse(options.url.toString()).path;
-                     let host = url.parse(options.url.toString()).host;
-                     let newFileUrl = url.resolve(opt_proxy, pathUrl);
-                     logger.info(
-                         'curl -o ' + outputDir + '/' + fileName + ' \'' + newFileUrl +
-                         '\' -H \'host:' + host + '\'');
-                   } else {
-                     logger.info('curl -o ' + outputDir + '/' + fileName + ' ' + fileUrl);
-                   }
-
                    // only pipe if the headers are different length
                    file = fs.createWriteStream(filePath);
                    req.pipe(file);

--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -169,9 +169,8 @@ export class FileManager {
    * @returns Promise resolved to true for files downloaded, resolved to false for files not
    *          downloaded because they exist, rejected if there is an error.
    */
-  static downloadFile<T extends Binary>(
-      binary: T, outputDir: string, opt_proxy?: string, opt_ignoreSSL?: boolean,
-      callback?: Function): Promise<boolean> {
+  static downloadFile<T extends Binary>(binary: T, outputDir: string, callback?: Function):
+      Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
 
       let outDir = Config.getSeleniumDir();
@@ -179,7 +178,7 @@ export class FileManager {
       let contentLength = 0;
 
       // Pass options down to binary to make request to get the latest version to download.
-      binary.getUrl(binary.version(), opt_proxy, opt_ignoreSSL).then(fileUrl => {
+      binary.getUrl(binary.version()).then(fileUrl => {
         binary.versionCustom = fileUrl.version;
         let filePath = path.resolve(outputDir, binary.filename());
         let fileName = binary.filename();
@@ -195,10 +194,7 @@ export class FileManager {
             if (v === version) {
               contentLength = fs.statSync(filePath).size;
 
-              Downloader
-                  .getFile(
-                      binary, fileUrl.url, fileName, outputDir, contentLength, opt_proxy,
-                      opt_ignoreSSL, callback)
+              Downloader.getFile(binary, fileUrl.url, fileName, outputDir, contentLength, callback)
                   .then(downloaded => {
                     resolve(downloaded);
                   });
@@ -207,10 +203,7 @@ export class FileManager {
         }
         // We have not downloaded it before, or the version does not exist. Use the default content
         // length of zero and download the file.
-        Downloader
-            .getFile(
-                binary, fileUrl.url, fileName, outputDir, contentLength, opt_proxy, opt_ignoreSSL,
-                callback)
+        Downloader.getFile(binary, fileUrl.url, fileName, outputDir, contentLength, callback)
             .then(downloaded => {
               resolve(downloaded);
             });

--- a/lib/http_utils.ts
+++ b/lib/http_utils.ts
@@ -6,7 +6,18 @@ import {Config} from './config';
 
 let logger = new Logger('http_utils');
 
+export declare interface RequestOptionsValue {
+  proxy?: string;
+  ignoreSSL?: boolean;
+}
+
+let requestOpts: RequestOptionsValue = {};
+
 export class HttpUtils {
+  static assignOptions(options: RequestOptionsValue): void {
+    Object.assign(requestOpts, options);
+  }
+
   static initOptions(url: string, timeout?: number): OptionsWithUrl {
     let options: OptionsWithUrl = {
       url: url,
@@ -14,6 +25,8 @@ export class HttpUtils {
       // increasing this arbitrarily to 4 minutes
       timeout: 240000
     };
+    HttpUtils.optionsSSL(options, requestOpts.ignoreSSL);
+    HttpUtils.optionsProxy(options, url, requestOpts.proxy);
     return options;
   }
 


### PR DESCRIPTION
Since these options are for every request in the update command, it's not necessary to explicitly pass them down to irrelevant instances (eg. binaries and config sources).