### PR TITLE
fixes #214 by removing cdn and using alternateDownloadUrl

### DIFF
--- a/lib/binaries/android_sdk.ts
+++ b/lib/binaries/android_sdk.ts
@@ -44,8 +44,11 @@ export class AndroidSDK extends Binary {
     25: '7.1'
   }
 
-  constructor(alternateCDN?: string) {
-    super(alternateCDN || Config.cdnUrls().android);
+  private cdn: string;
+
+  constructor(alternativeDownloadUrl?: string) {
+    super(alternativeDownloadUrl);
+    this.cdn = Config.cdnUrls().android;
 
     this.name = 'android-sdk';
     this.versionCustom = AndroidSDK.versionDefault;
@@ -57,6 +60,10 @@ export class AndroidSDK extends Binary {
 
   prefix(): string {
     return 'android-sdk_r';
+  }
+
+  version_concatenator(): string {
+    return '';
   }
 
   suffix(): string {

--- a/lib/binaries/appium.ts
+++ b/lib/binaries/appium.ts
@@ -15,8 +15,8 @@ export class Appium extends Binary {
   static versionDefault = Config.binaryVersions().appium;
   static isDefault = false;
 
-  constructor(alternateCDN?: string) {
-    super(alternateCDN || Config.cdnUrls().appium);
+  constructor(alternativeDownloadUrl?: string) {
+    super(alternativeDownloadUrl);
     this.name = 'appium';
     this.versionCustom = Appium.versionDefault;
   }
@@ -26,7 +26,11 @@ export class Appium extends Binary {
   }
 
   prefix(): string {
-    return 'appium-';
+    return 'appium';
+  }
+
+  version_concatenator(): string {
+    return '-';
   }
 
   suffix(): string {

--- a/lib/binaries/binary.ts
+++ b/lib/binaries/binary.ts
@@ -43,12 +43,15 @@ export abstract class Binary {
 
   constructor(opt_alternativeDownloadUrl?: string) {
     // if opt_alternativeDownloadUrl is a empty string, assign null for simpler checks
-    this.alternativeDownloadUrl = opt_alternativeDownloadUrl != null && opt_alternativeDownloadUrl.length > 0 ? opt_alternativeDownloadUrl : null;
+    this.alternativeDownloadUrl =
+        opt_alternativeDownloadUrl != null && opt_alternativeDownloadUrl.length > 0 ?
+        opt_alternativeDownloadUrl :
+        null;
   }
 
   abstract prefix(): string;
   abstract suffix(): string;
-  abstract version_concatenator(): string; // the string to concatenate prefix and version
+  abstract version_concatenator(): string;  // the string to concatenate prefix and version
 
   executableSuffix(): string {
     if (this.ostype == 'Windows_NT') {
@@ -63,7 +66,8 @@ export abstract class Binary {
   }
 
   filename(): string {
-    let version = this.alternativeDownloadUrl == null ? this.version_concatenator() + this.version() : '';
+    let version =
+        this.alternativeDownloadUrl == null ? this.version_concatenator() + this.version() : '';
     return this.prefix() + version + this.suffix();
   }
 
@@ -72,7 +76,8 @@ export abstract class Binary {
    * @returns The file name for the executable.
    */
   executableFilename(): string {
-    let version = this.alternativeDownloadUrl == null ? this.version_concatenator() + this.version() : '';
+    let version =
+        this.alternativeDownloadUrl == null ? this.version_concatenator() + this.version() : '';
     return this.prefix() + version + this.executableSuffix();
   }
 

--- a/lib/binaries/binary.ts
+++ b/lib/binaries/binary.ts
@@ -34,7 +34,6 @@ export abstract class Binary {
   //   the file from an alternative download URL.
   alternativeDownloadUrl: string;
 
-  cdn: string;             // The url host for XML reading or the base path to the url.
   opt_ignoreSSL: boolean;  // An optional ignore ssl.
   opt_proxy: string        // An optional proxy.
 
@@ -42,12 +41,14 @@ export abstract class Binary {
   versionDefault: string;
   versionCustom: string;
 
-  constructor(opt_alternativeCdn?: string) {
-    this.cdn = opt_alternativeCdn;
+  constructor(opt_alternativeDownloadUrl?: string) {
+    // if opt_alternativeDownloadUrl is a empty string, assign null for simpler checks
+    this.alternativeDownloadUrl = opt_alternativeDownloadUrl != null && opt_alternativeDownloadUrl.length > 0 ? opt_alternativeDownloadUrl : null;
   }
 
   abstract prefix(): string;
   abstract suffix(): string;
+  abstract version_concatenator(): string; // the string to concatenate prefix and version
 
   executableSuffix(): string {
     if (this.ostype == 'Windows_NT') {
@@ -62,7 +63,8 @@ export abstract class Binary {
   }
 
   filename(): string {
-    return this.prefix() + this.version() + this.suffix();
+    let version = this.alternativeDownloadUrl == null ? this.version_concatenator() + this.version() : '';
+    return this.prefix() + version + this.suffix();
   }
 
   /**
@@ -70,7 +72,8 @@ export abstract class Binary {
    * @returns The file name for the executable.
    */
   executableFilename(): string {
-    return this.prefix() + this.version() + this.executableSuffix();
+    let version = this.alternativeDownloadUrl == null ? this.version_concatenator() + this.version() : '';
+    return this.prefix() + version + this.executableSuffix();
   }
 
   /**
@@ -94,7 +97,9 @@ export abstract class Binary {
       this.configSource.opt_ignoreSSL = this.opt_ignoreSSL;
     }
     if (this.alternativeDownloadUrl != null) {
-      return Promise.resolve({url: '', version: ''});
+      // remove any trailing slashes on alternativeDownloadUrl
+      let url = this.alternativeDownloadUrl.replace(/\/+$/, '') + '/' + this.filename();
+      return Promise.resolve({url: url, version: ''});
     } else {
       return this.getVersionList().then(() => {
         version = version || Config.binaryVersions()[this.id()];

--- a/lib/binaries/chrome_driver.ts
+++ b/lib/binaries/chrome_driver.ts
@@ -9,8 +9,8 @@ export class ChromeDriver extends Binary {
   static os = [OS.Windows_NT, OS.Linux, OS.Darwin];
   static versionDefault = Config.binaryVersions().chrome;
 
-  constructor(opt_alternativeCdn?: string) {
-    super(opt_alternativeCdn || Config.cdnUrls().chrome);
+  constructor(alternativeDownloadUrl?: string) {
+    super(alternativeDownloadUrl);
     this.configSource = new ChromeXml();
     this.name = 'chromedriver';
     this.versionDefault = ChromeDriver.versionDefault;
@@ -22,7 +22,11 @@ export class ChromeDriver extends Binary {
   }
 
   prefix(): string {
-    return 'chromedriver_';
+    return 'chromedriver';
+  }
+
+  version_concatenator(): string {
+    return '_';
   }
 
   suffix(): string {
@@ -30,7 +34,7 @@ export class ChromeDriver extends Binary {
   }
 
   getVersionList(): Promise<string[]> {
-    // If an alternative cdn is set, return an empty list.
+    // If an alternative download url is set, return an empty list.
     if (this.alternativeDownloadUrl != null) {
       Promise.resolve([]);
     } else {

--- a/lib/binaries/gecko_driver.ts
+++ b/lib/binaries/gecko_driver.ts
@@ -24,8 +24,8 @@ export class GeckoDriver extends Binary {
     }
   };
 
-  constructor(opt_alternativeCdn?: string) {
-    super(opt_alternativeCdn || Config.cdnUrls().gecko);
+  constructor(alternativeDownloadUrl?: string) {
+    super(alternativeDownloadUrl);
     this.configSource = new GeckoDriverGithub();
     this.name = 'geckodriver';
     this.versionDefault = GeckoDriver.versionDefault;
@@ -37,7 +37,11 @@ export class GeckoDriver extends Binary {
   }
 
   prefix(): string {
-    return 'geckodriver-';
+    return 'geckodriver';
+  }
+
+  version_concatenator(): string {
+    return '-';
   }
 
   suffix(): string {

--- a/lib/binaries/iedriver.ts
+++ b/lib/binaries/iedriver.ts
@@ -10,8 +10,8 @@ export class IEDriver extends Binary {
   static os = [OS.Windows_NT];
   static versionDefault = Config.binaryVersions().ie;
 
-  constructor(opt_alternativeCdn?: string) {
-    super(opt_alternativeCdn || Config.cdnUrls().ie);
+  constructor(alternativeDownloadUrl?: string) {
+    super(alternativeDownloadUrl);
     this.configSource = new IEDriverXml();
     this.name = 'IEDriverServer';
     this.versionDefault = IEDriver.versionDefault;
@@ -24,6 +24,10 @@ export class IEDriver extends Binary {
 
   prefix(): string {
     return 'IEDriverServer';
+  }
+
+  version_concatenator(): string {
+    return '';
   }
 
   suffix(): string {

--- a/lib/binaries/standalone.ts
+++ b/lib/binaries/standalone.ts
@@ -10,8 +10,8 @@ export class Standalone extends Binary {
   static os = [OS.Windows_NT, OS.Linux, OS.Darwin];
   static versionDefault = Config.binaryVersions().selenium;
 
-  constructor(opt_alternativeCdn?: string) {
-    super(opt_alternativeCdn || Config.cdnUrls().selenium);
+  constructor(opt_alternativeDownloadUrl?: string) {
+    super(opt_alternativeDownloadUrl);
     this.configSource = new StandaloneXml();
     this.name = 'selenium standalone';
     this.versionDefault = Standalone.versionDefault;
@@ -23,7 +23,11 @@ export class Standalone extends Binary {
   }
 
   prefix(): string {
-    return 'selenium-server-standalone-';
+    return 'selenium-server-standalone';
+  }
+
+  version_concatenator(): string {
+    return '-';
   }
 
   suffix(): string {
@@ -35,7 +39,7 @@ export class Standalone extends Binary {
   }
 
   getVersionList(): Promise<string[]> {
-    // If an alternative cdn is set, return an empty list.
+    // If an alternative download url is set, return an empty list.
     if (this.alternativeDownloadUrl != null) {
       return Promise.resolve([]);
     } else {

--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -53,7 +53,8 @@ opts[AVD_PORT] = new Option(
     5554);
 opts[IGNORE_SSL] = new Option(IGNORE_SSL, 'Ignore SSL certificates', 'boolean', false);
 opts[PROXY] = new Option(PROXY, 'Proxy to use for the install or update command', 'string');
-opts[ALTERNATE_DOWNLOAD_URL] = new Option(ALTERNATE_DOWNLOAD_URL, 'Alternate Url to download binaries', 'string');
+opts[ALTERNATE_DOWNLOAD_URL] =
+    new Option(ALTERNATE_DOWNLOAD_URL, 'Alternate Url to download binaries', 'string');
 opts[STANDALONE] = new Option(
     STANDALONE, 'Install or update selenium standalone', 'boolean', Standalone.isDefault);
 opts[CHROME] =

--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -8,7 +8,7 @@ export const APPIUM_PORT = 'appium-port';
 export const AVD_PORT = 'avd-port';
 export const IGNORE_SSL = 'ignore_ssl';
 export const PROXY = 'proxy';
-export const ALTERNATE_CDN = 'alternate_cdn';
+export const ALTERNATE_DOWNLOAD_URL = 'alternate_download_url';
 export const STANDALONE = 'standalone';
 export const CHROME = 'chrome';
 export const IE = 'ie';
@@ -53,7 +53,7 @@ opts[AVD_PORT] = new Option(
     5554);
 opts[IGNORE_SSL] = new Option(IGNORE_SSL, 'Ignore SSL certificates', 'boolean', false);
 opts[PROXY] = new Option(PROXY, 'Proxy to use for the install or update command', 'string');
-opts[ALTERNATE_CDN] = new Option(ALTERNATE_CDN, 'Alternate CDN to binaries', 'string');
+opts[ALTERNATE_DOWNLOAD_URL] = new Option(ALTERNATE_DOWNLOAD_URL, 'Alternate Url to download binaries', 'string');
 opts[STANDALONE] = new Option(
     STANDALONE, 'Install or update selenium standalone', 'boolean', Standalone.isDefault);
 opts[CHROME] =

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -24,6 +24,7 @@ let prog = new Program()
                .addOption(Opts[Opt.SELENIUM_PORT])
                .addOption(Opts[Opt.APPIUM_PORT])
                .addOption(Opts[Opt.AVD_PORT])
+               .addOption(Opts[Opt.ALTERNATE_DOWNLOAD_URL])
                .addOption(Opts[Opt.VERSIONS_STANDALONE])
                .addOption(Opts[Opt.VERSIONS_CHROME])
                .addOption(Opts[Opt.VERSIONS_GECKO])
@@ -72,7 +73,7 @@ function start(options: Options) {
 
   let osType = Config.osType();
   let stdio = options[Opt.QUIET].getBoolean() ? 'pipe' : 'inherit';
-  let binaries = FileManager.setupBinaries();
+  let binaries = FileManager.setupBinaries(options[Opt.ALTERNATE_DOWNLOAD_URL].getString());
   let seleniumPort = options[Opt.SELENIUM_PORT].getString();
   let appiumPort = options[Opt.APPIUM_PORT].getString();
   let avdPort = options[Opt.AVD_PORT].getNumber();

--- a/lib/cmds/status.ts
+++ b/lib/cmds/status.ts
@@ -14,6 +14,7 @@ import {Opts} from './opts';
 let logger = new Logger('status');
 let prog = new Program()
                .command('status', 'list the current available drivers')
+               .addOption(Opts[Opt.ALTERNATE_DOWNLOAD_URL])
                .addOption(Opts[Opt.OUT_DIR])
                .action(status);
 
@@ -32,7 +33,7 @@ if (argv._[0] === 'status-run') {
  * @param options
  */
 function status(options: Options) {
-  let binaries = FileManager.setupBinaries();
+  let binaries = FileManager.setupBinaries(options[Opt.ALTERNATE_DOWNLOAD_URL].getString());
   let outputDir = Config.getSeleniumDir();
   if (options[Opt.OUT_DIR].value) {
     if (path.isAbsolute(options[Opt.OUT_DIR].getString())) {

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -225,7 +225,7 @@ function updateBinary<T extends Binary>(
           let fileName = binary.filename();
           unzip(binary, outputDir, fileName);
           logger.info(binary.name + ': ' + binary.executableFilename() + ' up to date');
-        } else if(downloaded === undefined) {
+        } else if (downloaded === undefined) {
           logger.info(binary.name + ': could not be downloaded');
         }
       });

--- a/lib/files/downloaded_binary.ts
+++ b/lib/files/downloaded_binary.ts
@@ -21,6 +21,9 @@ export class DownloadedBinary extends Binary {
   prefix(): string {
     return null;
   }
+  version_concatenator(): string {
+    return null;
+  }
   suffix(): string {
     return null;
   }

--- a/lib/files/downloader.ts
+++ b/lib/files/downloader.ts
@@ -99,7 +99,7 @@ export class Downloader {
                  error.msg = 'Connection timeout downloading: ' + fileUrl +
                      '. Default timeout is 4 minutes.';
                } else if(error.code === 'ECONNREFUSED') {
-                   error.msg = 'Could not connect to ' + error.address + ':' + error.port;
+                 error.msg = 'Could not connect to ' + error.address + ':' + error.port;
                } else if (error.connect) {
                  error.msg = 'Could not connect to the server to download: ' + fileUrl;
                }
@@ -107,7 +107,7 @@ export class Downloader {
              });
            })
         .catch((error: any) => {
-            logger.error(error.msg);
+          logger.error(error.msg);
         });
   }
 }

--- a/lib/files/downloader.ts
+++ b/lib/files/downloader.ts
@@ -73,10 +73,11 @@ export class Downloader {
                          return reject(error);
                        }
                        if (stats.size != resContentLength) {
-                         (error as any).msg = 'Error: corrupt download for ' + fileName +
+                         let err: any = error || new Error();
+                         err.msg = 'Error: corrupt download for ' + fileName +
                              '. Please re-run webdriver-manager update';
                          fs.unlinkSync(filePath);
-                         reject(error);
+                         reject(err);
                        }
                        if (callback) {
                          callback(binary, outputDir, fileName);
@@ -93,18 +94,20 @@ export class Downloader {
                  reject(error);
                }
              });
-             req.on('error', error => {
-               if ((error as any).code === 'ETIMEDOUT') {
-                 (error as any).msg = 'Connection timeout downloading: ' + fileUrl +
+             req.on('error', (error: any) => {
+               if (error.code === 'ETIMEDOUT') {
+                 error.msg = 'Connection timeout downloading: ' + fileUrl +
                      '. Default timeout is 4 minutes.';
-               } else if ((error as any).connect) {
-                 (error as any).msg = 'Could not connect to the server to download: ' + fileUrl;
+               } else if(error.code === 'ECONNREFUSED') {
+                   error.msg = 'Could not connect to ' + error.address + ':' + error.port;
+               } else if (error.connect) {
+                 error.msg = 'Could not connect to the server to download: ' + fileUrl;
                }
                reject(error);
              });
            })
-        .catch(error => {
-          logger.error((error as any).msg);
+        .catch((error: any) => {
+            logger.error(error.msg);
         });
   }
 }

--- a/lib/files/downloader.ts
+++ b/lib/files/downloader.ts
@@ -98,7 +98,7 @@ export class Downloader {
                if (error.code === 'ETIMEDOUT') {
                  error.msg = 'Connection timeout downloading: ' + fileUrl +
                      '. Default timeout is 4 minutes.';
-               } else if(error.code === 'ECONNREFUSED') {
+               } else if (error.code === 'ECONNREFUSED') {
                  error.msg = 'Could not connect to ' + error.address + ':' + error.port;
                } else if (error.connect) {
                  error.msg = 'Could not connect to the server to download: ' + fileUrl;

--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -53,25 +53,25 @@ export class FileManager {
    * @param alternateCDN URL of the alternative CDN to be used instead of the default ones.
    * @returns A binary map that are available for the operating system.
    */
-  static compileBinaries_(osType: string, alternateCDN?: string): BinaryMap<Binary> {
+  static compileBinaries_(osType: string, alternateDownloadUrl?: string): BinaryMap<Binary> {
     let binaries: BinaryMap<Binary> = {};
     if (FileManager.checkOS_(osType, Standalone)) {
-      binaries[Standalone.id] = new Standalone(alternateCDN);
+      binaries[Standalone.id] = new Standalone(alternateDownloadUrl);
     }
     if (FileManager.checkOS_(osType, ChromeDriver)) {
-      binaries[ChromeDriver.id] = new ChromeDriver(alternateCDN);
+      binaries[ChromeDriver.id] = new ChromeDriver(alternateDownloadUrl);
     }
     if (FileManager.checkOS_(osType, GeckoDriver)) {
-      binaries[GeckoDriver.id] = new GeckoDriver(alternateCDN);
+      binaries[GeckoDriver.id] = new GeckoDriver(alternateDownloadUrl);
     }
     if (FileManager.checkOS_(osType, IEDriver)) {
-      binaries[IEDriver.id] = new IEDriver(alternateCDN);
+      binaries[IEDriver.id] = new IEDriver(alternateDownloadUrl);
     }
     if (FileManager.checkOS_(osType, AndroidSDK)) {
-      binaries[AndroidSDK.id] = new AndroidSDK(alternateCDN);
+      binaries[AndroidSDK.id] = new AndroidSDK(alternateDownloadUrl);
     }
     if (FileManager.checkOS_(osType, Appium)) {
-      binaries[Appium.id] = new Appium(alternateCDN);
+      binaries[Appium.id] = new Appium(alternateDownloadUrl);
     }
     return binaries;
   }
@@ -82,8 +82,8 @@ export class FileManager {
    * @param alternateCDN URL of the alternative CDN to be used instead of the default ones.
    * @returns A binary map that is available for the operating system.
    */
-  static setupBinaries(alternateCDN?: string): BinaryMap<Binary> {
-    return FileManager.compileBinaries_(Config.osType(), alternateCDN);
+  static setupBinaries(alternateDownloadUrl?: string): BinaryMap<Binary> {
+    return FileManager.compileBinaries_(Config.osType(), alternateDownloadUrl);
   }
 
   /**

--- a/spec/files/file_manager_spec.ts
+++ b/spec/files/file_manager_spec.ts
@@ -219,54 +219,5 @@ describe('file manager', () => {
     });
   });
 
-  describe('configuring the CDN location', () => {
-
-    describe('when no custom CDN is specified', () => {
-
-      let defaults = Config.cdnUrls();
-      let binaries = FileManager.compileBinaries_('Windows_NT');
-
-      it('should use the default configuration for Android SDK', () => {
-        expect(binaries[AndroidSDK.id].cdn).toEqual(defaults[AndroidSDK.id]);
-      });
-
-      it('should use the default configuration for Appium', () => {
-        expect(binaries[Appium.id].cdn).toEqual(defaults[Appium.id]);
-      });
-
-      it('should use the default configuration for Chrome Driver', () => {
-        expect(binaries[ChromeDriver.id].cdn).toEqual(defaults[ChromeDriver.id]);
-      });
-
-      it('should use the default configuration for Gecko Driver', () => {
-        expect(binaries[GeckoDriver.id].cdn).toEqual(defaults[GeckoDriver.id]);
-      });
-
-      it('should use the default configuration for IE Driver', () => {
-        expect(binaries[IEDriver.id].cdn).toEqual(defaults[IEDriver.id]);
-      });
-
-      it('should use the default configuration for Selenium Standalone', () => {
-        expect(binaries[Standalone.id].cdn).toEqual(defaults['selenium']);
-      });
-    });
-
-    describe('when custom CDN is specified', () => {
-
-      it('should configure the CDN for each binary', () => {
-        let customCDN = 'https://my.corporate.cdn/';
-        let binaries = FileManager.compileBinaries_('Windows_NT', customCDN);
-
-        forEachOf(binaries, binary => expect(binary.cdn).toEqual(customCDN, binary.name));
-      });
-    });
-
-    function forEachOf<T extends Binary>(binaries: BinaryMap<T>, fn: (binary: T) => void) {
-      for (var key in binaries) {
-        fn(binaries[key]);
-      }
-    }
-  });
-
   // TODO(cnishina): download binaries for each os type / arch combination
 });


### PR DESCRIPTION
@cnishina Here is an implementation to fix #214.
I could provide also some tests, but for today there is no more time left for working on this.

What should be tested is if everything is working without parameters like proxy or alternate_download_url, but i can't do this because of our companies proxy.

The intended purpose of the new flag:
$ webdriver-manager update --alternate_download_url=http://localhost:8080/

webdriver-manager will then try to download from this host the files without version, e.g. chromedriver.zip instead of chromedriver_2.28.zip.