### PR TITLE
fix(cli/start) - swithed appiumPort for seleniumPort

### DIFF
--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -433,7 +433,7 @@ function signalWhenReady(
   }
   let pending = [waitFor(
       () => {
-        return request('GET', appiumPort, '/wd/hub/status', maxWait);
+        return request('GET', seleniumPort, '/wd/hub/status', maxWait);
       },
       (status) => {
         return JSON.parse(status).status == 0;

--- a/spec/cmds/status_spec.ts
+++ b/spec/cmds/status_spec.ts
@@ -34,7 +34,7 @@ describe('status', () => {
         .catch(err => {
           done.fail();
         });
-  });
+  }, 10000);
 
   it('should show the version number of the default and latest versions', () => {
     let lines =


### PR DESCRIPTION
Listening for appiumPort when selenium server was launched never triggered OK status to detach process.