### PR TITLE
Fix: webdriver clean

### DIFF
--- a/lib/files/file_manager.ts
+++ b/lib/files/file_manager.ts
@@ -241,7 +241,7 @@ export class FileManager {
     });
 
     let metaFiles = [
-      'chromedriver-response.xml', 'gecko-response.json', 'iedriver-response.xml',
+      'chrome-response.xml', 'gecko-response.json', 'iedriver-response.xml',
       'standalone-response.xml', 'update-config.json'
     ];
     for (let metaFile of metaFiles) {


### PR DESCRIPTION
webdriver-manager clean does not remove chrome.xml. The metaFiles reference has a different name chromedriver-response.xml in the list causing the problem.
This PR will address that issue.