### PR TITLE
fix(selenium): download jar files and not zip files

### DIFF
--- a/lib/binaries/standalone_xml.ts
+++ b/lib/binaries/standalone_xml.ts
@@ -39,23 +39,23 @@ export class StandaloneXml extends XmlConfigSource {
       let standaloneVersion: string = null;
       let latest = '';
       let latestVersion = '';
-      for (let item of list) {
+      // Use jar files that are not beta and not alpha versions.
+      const jarList = list.filter((i) => {
+        return i.endsWith('.jar') && !i.includes('beta') && !i.includes('alpha');
+      });
+      for (let item of jarList) {
         // Get a semantic version.
         let version = item.split('selenium-server-standalone-')[1].replace('.jar', '');
-
-        // Do not do beta versions for latest.
-        if (!version.includes('beta')) {
-          if (standaloneVersion == null) {
-            // First time: use the version found.
-            standaloneVersion = version;
-            latest = item;
-            latestVersion = version;
-          } else if (semver.gt(version, standaloneVersion)) {
-            // Get the latest.
-            standaloneVersion = version;
-            latest = item;
-            latestVersion = version;
-          }
+        if (standaloneVersion == null) {
+          // First time: use the version found.
+          standaloneVersion = version;
+          latest = item;
+          latestVersion = version;
+        } else if (semver.gt(version, standaloneVersion)) {
+          // Get the latest.
+          standaloneVersion = version;
+          latest = item;
+          latestVersion = version;
         }
       }
       return {url: Config.cdnUrls().selenium + latest, version: latestVersion};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1567,7 +1567,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1588,12 +1589,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1608,17 +1611,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1735,7 +1741,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1747,6 +1754,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1761,6 +1769,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1768,12 +1777,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1792,6 +1803,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1872,7 +1884,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1884,6 +1897,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1969,7 +1983,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2005,6 +2020,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2024,6 +2040,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2067,12 +2084,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
This fix is here because selenium now has .zip files in the .xml. This
worked previously since there were no .zip files and it would find the
first version that matched the latest jar file.

Fix for legacy branch to update.

Closes #370