### PR TITLE
fix(chromedriver): support downloads for chromedriver beyond 2.46

### DIFF
--- a/lib/binaries/chrome_xml.ts
+++ b/lib/binaries/chrome_xml.ts
@@ -68,25 +68,48 @@ export class ChromeXml extends XmlConfigSource {
         // Get a semantic version
         let version = item.split('/')[0];
         if (semver.valid(version) == null) {
-          version += '.0';
-          if (semver.valid(version)) {
-            // First time: use the version found.
-            if (chromedriverVersion == null) {
-              chromedriverVersion = version;
-              latest = item;
-              latestVersion = item.split('/')[0];
-            } else if (semver.gt(version, chromedriverVersion)) {
-              // After the first time, make sure the semantic version is greater.
-              chromedriverVersion = version;
-              latest = item;
-              latestVersion = item.split('/')[0];
-            } else if (version === chromedriverVersion) {
-              // If the semantic version is the same, check os arch.
-              // For 64-bit systems, prefer the 64-bit version.
-              if (this.osarch === 'x64') {
-                if (item.includes(this.getOsTypeName() + '64')) {
-                  latest = item;
-                }
+          
+          // This supports downloading 74.0.3729.6
+          try {
+            const newRegex = /(\d+.\d+.\d+).\d+/g;
+            const exec = newRegex.exec(version);
+            if (exec) {
+              version = exec[1];
+            }
+          } catch(_) {
+            // no-op: if this does not work, use the other regex pattern.
+          }
+          
+          // This supports downloading 2.46
+          try {
+            const oldRegex = /(\d+.\d+)/g;
+            const exec = oldRegex.exec(version);
+            if (exec) {
+              version = exec[1] + '.0';
+            }
+          } catch (_) {
+            // no-op: is this is not valid, do not throw here.
+          }
+
+          if (!semver.valid(version)) {
+            throw new Error('invalid Chromedriver version');
+          }
+          // First time: use the version found.
+          if (chromedriverVersion == null) {
+            chromedriverVersion = version;
+            latest = item;
+            latestVersion = item.split('/')[0];
+          } else if (semver.gt(version, chromedriverVersion)) {
+            // After the first time, make sure the semantic version is greater.
+            chromedriverVersion = version;
+            latest = item;
+            latestVersion = item.split('/')[0];
+          } else if (version === chromedriverVersion) {
+            // If the semantic version is the same, check os arch.
+            // For 64-bit systems, prefer the 64-bit version.
+            if (this.osarch === 'x64') {
+              if (item.includes(this.getOsTypeName() + '64')) {
+                latest = item;
               }
             }
           }


### PR DESCRIPTION
Versions of Chromdriver were versioned as 2.xx. We previously used to
tack on a '.0' at the end to make it a semver version. This is why it
was not downloading 74.0.3729.6. We now have to change 74.0.3729.6 to be
a semver. We will do this by grabbing 74.0.3729 with a regex.

This should work when downloading the latest chromedriver version since
2.46.0 < 74.0.3729. If Chromedriver releases 75 but we are still on
Chrome 74, this will still break in this version of webdriver-manager.
This does not prevent latest Chromedriver and latest Chrome mismatches.
If you run into an issue where Chromedriver is mismatched with Chrome,
use the --versions.chrome flag to pass in the version to download.