### PR TITLE
fix(chromedriver): version fixes for update, status, and start

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "webdriverVersions": {
     "selenium": "2.53.1",
     "chromedriver": "2.27",
+    "maxChromedriver": "74",
     "geckodriver": "v0.13.0",
     "iedriver": "2.53.1",
     "androidsdk": "24.4.1",

--- a/lib/cmds/status.ts
+++ b/lib/cmds/status.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 
 import {AndroidSDK, Appium, ChromeDriver, GeckoDriver, IEDriver, Standalone} from '../binaries';
+import {getValidSemver} from '../binaries/chrome_xml';
 import {Logger, Options, Program} from '../cli';
 import {Config} from '../config';
 import {FileManager} from '../files';
@@ -88,8 +89,8 @@ function status(options: Options) {
     // - last: the last binary downloaded by webdriver-manager per the update-config.json
     downloaded.versions = downloaded.versions.sort((a: string, b: string): number => {
       if (!semver.valid(a)) {
-        a += '.0';
-        b += '.0';
+        a = getValidSemver(a);
+        b = getValidSemver(b);
       }
       if (semver.gt(a, b)) {
         return 1;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -15,6 +15,7 @@ export interface ConfigFile {
   ie?: string;
   android?: string;
   appium?: string;
+  maxChrome?: string;
 }
 
 /**
@@ -94,6 +95,7 @@ export class Config {
     configVersions.ie = configFile.webdriverVersions.iedriver;
     configVersions.android = configFile.webdriverVersions.androidsdk;
     configVersions.appium = configFile.webdriverVersions.appium;
+    configVersions.maxChrome = configFile.webdriverVersions.maxChromedriver;
     return configVersions;
   }
 


### PR DESCRIPTION
- Set the max versioning set in config.json. This will need to be updated on
every release of chromedriver. This will "fix" chrome and chromedriver
mismatches until Chrome 75 comes out. When it does there will have to be
an update for this again. Possible future work would allow a user
to set this via flag. Example --maxVersions.chrome "74."
- Create a generic way to get a valid version for Chromedriver. If
presented with 2.x, change this to 2.x.0. If presented with a 74.x.x.x,
chop off the last set of numbers and change this to 74.x.x
  - Fixes the status command during a semver check.
  - Fixes the update and start command when starting a specific version of
chromedriver