### PR TITLE
chore(chromium): add chromium to cli and lib

### DIFF
--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -18,6 +18,12 @@ const chromedriverLogsOption: yargs.Options = {
   describe: 'File path to chrome logs.',
   type: 'string'
 };
+const CHROMIUM = 'chromium';
+const chromiumOptions: yargs.Options = {
+  describe: 'Download chromium.',
+  default: false,
+  type: 'boolean'
+};
 const DETACH = 'detach';
 const detachOption: yargs.Options = {
   describe: 'Once the selenium server is up and running, return ' +
@@ -66,6 +72,11 @@ const MAX_VERSIONS_CHROMEDRIVER_ALIAS = 'max_versions.chrome';
 const MAX_VERSIONS_CHROMEDRIVER = 'max_versions.chromedriver';
 const maxVersionsChromedriverOption: yargs.Options = {
   describe: 'The chromedriver max version used only for update.',
+  type: 'string'
+};
+const MAX_VERSIONS_CHROMIUM = 'max_versions.chromium';
+const maxVersionsChromiumOptions: yargs.Options = {
+  describe: 'The chromium max version used only for update.',
   type: 'string'
 };
 const MAX_VERSIONS_GECKODRIVER_ALIAS = 'max_versions.gecko';
@@ -214,6 +225,7 @@ yargs
           return yargs.option(OUT_DIR, outDirOption)
               .option(CHROMEDRIVER, chromedriverOption)
               .alias(CHROMEDRIVER_ALIAS, CHROMEDRIVER)
+              .option(CHROMIUM, chromiumOptions)
               .option(GECKODRIVER, geckodriverOption)
               .alias(GECKODRIVER_ALIAS, GECKODRIVER)
               .option(GITHUB_TOKEN, githubTokenOption)
@@ -223,11 +235,13 @@ yargs
               .option(LOG_LEVEL, logLevelOption)
               .option(MAX_VERSIONS_CHROMEDRIVER, maxVersionsChromedriverOption)
               .alias(MAX_VERSIONS_CHROMEDRIVER_ALIAS, MAX_VERSIONS_CHROMEDRIVER)
+              .option(MAX_VERSIONS_CHROMIUM, maxVersionsChromiumOptions)
               .option(MAX_VERSIONS_GECKODRIVER, maxVersionsGeckodriverOption)
               .alias(MAX_VERSIONS_GECKODRIVER_ALIAS, MAX_VERSIONS_GECKODRIVER)
               .option(MAX_VERSIONS_IEDRIVER, maxVersionsIedriverOption)
               .alias(MAX_VERSIONS_IEDRIVER_ALIAS, MAX_VERSIONS_IEDRIVER)
               .option(MAX_VERSIONS_SELENIUM, maxVersionsSeleniumOption)
+              .alias(MAX_VERSIONS_SELENIUM_ALIAS, MAX_VERSIONS_SELENIUM)
               .option(OUT_DIR, outDirOption)
               .option(PROXY, proxyOption)
               .option(SELENIUM, seleniumOption)

--- a/lib/cmds/options.ts
+++ b/lib/cmds/options.ts
@@ -16,7 +16,8 @@ export interface Options {
   githubToken?: string;
 }
 
-export type BrowserDriverName = 'chromedriver'|'geckodriver'|'iedriver';
+export type BrowserDriverName =
+  'chromedriver'|'geckodriver'|'iedriver'|'chromium';
 
 /**
  * Contains information about a browser driver.

--- a/lib/cmds/utils.spec-unit.ts
+++ b/lib/cmds/utils.spec-unit.ts
@@ -13,7 +13,7 @@ describe('utils', () => {
       };
       const options = convertArgs2AllOptions(argv);
       expect(options.browserDrivers).toBeTruthy();
-      expect(options.browserDrivers.length).toBe(3);
+      expect(options.browserDrivers.length).toBe(4);
       expect(options.server).toBeTruthy();
       expect(options.server.name).toBe('selenium');
       expect(options.outDir).toBe('foobar_download');

--- a/lib/cmds/utils.ts
+++ b/lib/cmds/utils.ts
@@ -7,6 +7,7 @@ import {SeleniumServer, SeleniumServerProviderConfig} from '../provider/selenium
 
 import {BrowserDriver, BrowserDriverName, Options} from './options';
 import {OptionsBinary} from './options_binary';
+import { Chromium } from '../provider/chromium';
 
 /**
  * Converts an options object into an options binary object.
@@ -27,6 +28,8 @@ export function addOptionsBinary(options: Options): OptionsBinary {
     for (const browserDriver of optionsBinary.browserDrivers) {
       if (browserDriver.name === 'chromedriver') {
         browserDriver.binary = new ChromeDriver(providerConfig);
+      } else if (browserDriver.name === 'chromium') {
+        browserDriver.binary = new Chromium(providerConfig);
       } else if (browserDriver.name === 'geckodriver') {
         const geckoProviderConfig = providerConfig;
         geckoProviderConfig.oauthToken = optionsBinary.githubToken;
@@ -57,6 +60,7 @@ export function convertArgs2AllOptions(argv: yargs.Arguments): Options {
   return {
     browserDrivers: [
       {name: 'chromedriver'},
+      {name: 'chromium'},
       {name: 'geckodriver'},
       {name: 'iedriver'}
     ],
@@ -82,6 +86,9 @@ export function convertArgs2Options(argv: yargs.Arguments): Options {
 
   if (argv['chromedriver'] as boolean) {
     setVersions('chromedriver', argv, options.browserDrivers);
+  }
+  if (argv['chromium'] as boolean) {
+    setVersions('chromium', argv, options.browserDrivers);
   }
   if (argv['geckodriver'] as boolean) {
     setVersions('geckodriver', argv, options.browserDrivers);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,7 @@ export {start} from './cmds/start';
 export {status} from './cmds/status';
 export {update} from './cmds/update';
 export {ChromeDriver} from './provider/chromedriver';
+export {Chromium} from './provider/chromium';
 export {GeckoDriver} from './provider/geckodriver';
 export {IEDriver} from './provider/iedriver';
 export {ProviderConfig, ProviderInterface} from './provider/provider';

--- a/lib/provider/utils/file_utils.ts
+++ b/lib/provider/utils/file_utils.ts
@@ -105,7 +105,6 @@ export function unzipFile(zipFileName: string, dstDir: string): string[] {
   const zip = new AdmZip(zipFileName);
   zip.extractAllTo(dstDir, true);
   for (const fileItem of zipFileList(zipFileName)) {
-    console.log(fileItem);
     fileList.push(path.resolve(dstDir, fileItem));
   }
   return fileList;


### PR DESCRIPTION
Most of these methods do not work with Windows and there still needs to
have some tests against the chromium.ts file.

- provide hooks when used in cli and as a node module
- fix update to only have one version of chromium
- add methods to get the binary file from the chromium.config.json
- add clean and status methods