### PR TITLE
Updates maxChromedriver to 77

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "webdriverVersions": {
     "selenium": "2.53.1",
     "chromedriver": "2.27",
-    "maxChromedriver": "76",
+    "maxChromedriver": "77",
     "geckodriver": "v0.13.0",
     "iedriver": "2.53.1",
     "androidsdk": "24.4.1",


### PR DESCRIPTION
See: https://chromereleases.googleblog.com/2019/09/stable-channel-update-for-desktop.html