### PR TITLE
Fix alternate CDN

### DIFF
--- a/lib/binaries/chrome_driver.ts
+++ b/lib/binaries/chrome_driver.ts
@@ -11,7 +11,7 @@ export class ChromeDriver extends Binary {
 
   constructor(opt_alternativeCdn?: string) {
     super(opt_alternativeCdn || Config.cdnUrls().chrome);
-    this.configSource = new ChromeXml();
+    this.configSource = new ChromeXml(opt_alternativeCdn);
     this.name = 'chromedriver';
     this.versionDefault = ChromeDriver.versionDefault;
     this.versionCustom = this.versionDefault;

--- a/lib/binaries/chrome_xml.ts
+++ b/lib/binaries/chrome_xml.ts
@@ -9,8 +9,8 @@ import {XmlConfigSource} from './config_source';
 export class ChromeXml extends XmlConfigSource {
   maxVersion = Config.binaryVersions().maxChrome;
 
-  constructor() {
-    super('chrome', Config.cdnUrls()['chrome']);
+  constructor(opt_alternativeCdn?: string) {
+    super('chrome', opt_alternativeCdn || Config.cdnUrls()['chrome']);
   }
 
   getUrl(version: string): Promise<BinaryUrl> {
@@ -63,7 +63,7 @@ export class ChromeXml extends XmlConfigSource {
    * Gets the latest item from the XML.
    */
   private getLatestChromeDriverVersion(): Promise<BinaryUrl> {
-    const latestReleaseUrl = 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE';
+    const latestReleaseUrl = `${this.xmlUrl}/LATEST_RELEASE`;
     return requestBody(latestReleaseUrl).then(latestVersion => {
       return this.getSpecificChromeDriverVersion(latestVersion);
     });
@@ -111,7 +111,7 @@ export class ChromeXml extends XmlConfigSource {
       if (itemFound == '') {
         return {url: '', version: inputVersion};
       } else {
-        return {url: Config.cdnUrls().chrome + itemFound, version: inputVersion};
+        return {url: this.xmlUrl + itemFound, version: inputVersion};
       }
     });
   }


### PR DESCRIPTION
Fix the bug described in #325 .

Trying to download chromedriver with --alternate_cdn had no effect and the binary was fetched from Google's CDN instead of the CDN provided on the cli.

We need this in order to fetch all binaries used in our CI pipeline through the company's private mirror (nexus-based).