### PR TITLE
feat: add option to specify versions via env variables

### DIFF
--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -118,14 +118,19 @@ function update(options: Options): Promise<void> {
   let verbose = options[Opt.VERBOSE].getBoolean();
 
   // setup versions for binaries
+  let environment = process.env;
   let binaries = FileManager.setupBinaries(options[Opt.ALTERNATE_CDN].getString());
-  binaries[Standalone.id].versionCustom = options[Opt.VERSIONS_STANDALONE].getString();
-  binaries[ChromeDriver.id].versionCustom = options[Opt.VERSIONS_CHROME].getString();
+  binaries[Standalone.id].versionCustom =
+      environment.VERSIONS_STANDALONE || options[Opt.VERSIONS_STANDALONE].getString();
+  binaries[ChromeDriver.id].versionCustom =
+      environment.VERSIONS_CHROME || options[Opt.VERSIONS_CHROME].getString();
   if (options[Opt.VERSIONS_IE]) {
-    binaries[IEDriver.id].versionCustom = options[Opt.VERSIONS_IE].getString();
+    binaries[IEDriver.id].versionCustom =
+        environment.VERSIONS_IE || options[Opt.VERSIONS_IE].getString();
   }
   if (options[Opt.VERSIONS_GECKO]) {
-    binaries[GeckoDriver.id].versionCustom = options[Opt.VERSIONS_GECKO].getString();
+    binaries[GeckoDriver.id].versionCustom =
+        environment.VERSIONS_GECKO || options[Opt.VERSIONS_GECKO].getString();
   }
   binaries[AndroidSDK.id].versionCustom = options[Opt.VERSIONS_ANDROID].getString();
   binaries[Appium.id].versionCustom = options[Opt.VERSIONS_APPIUM].getString();


### PR DESCRIPTION
Provide an alternatives to options like `--versions.xxx` using environment variables.

Issues like https://github.com/angular/webdriver-manager/issues/468 are a recurring problem in my CI.
Most of the time bumping the Chrome version fixes the problem for us.

But this time, Chrome 85 is not released yet, bu ChromeDriver is already at 85.
There's no simple/one-liner way to fix this.

What I suggest is to add these variables, specially for people using Protractor.

For example, we can easily determine which version of Chrome is available with this command:
```
$ CHROME_VERSION=google-chrome-stable --version | grep -Po '(\d+)(?=\.\d+\.\d+\.\d+)'
```

Then we can determine which version of ChromeDriver to download with the following:
```
$ CHROMEDRIVER_VERSION=`curl -sS https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION`
```

And finally, we can override whatever version webdriver-manager detects, when called by Protractor, to download the appropriate driver.

```
VERSIONS_CHROME=$CHROMEDRIVER_VERSION ng e2e
```