### PR TITLE
fix(chromedriver): get most recent version on x64 windows if multiple major versions exist

### DIFF
--- a/lib/binaries/chrome_xml.ts
+++ b/lib/binaries/chrome_xml.ts
@@ -100,7 +100,11 @@ export class ChromeXml extends XmlConfigSource {
               // If the semantic version is the same, check os arch.
               // For 64-bit systems, prefer the 64-bit version.
               else if (this.osarch === 'x64') {
-                if (item.includes(this.getOsTypeName() + '64')) {
+                // No win64 version exists, so even on x64 we need to look for win32
+                const osTypeNameAndArch =
+                    this.getOsTypeName() + (this.getOsTypeName() === 'win' ? '32' : '64');
+
+                if (item.includes(osTypeNameAndArch)) {
                   itemFound = item;
                 }
               }

--- a/spec/binaries/chrome_xml_spec.ts
+++ b/spec/binaries/chrome_xml_spec.ts
@@ -77,6 +77,7 @@ describe('chrome xml reader', () => {
     chromeXml.getUrl('85.0.4183.87').then((binaryUrl) => {
       expect(binaryUrl.url).toContain('85.0.4183.87/chromedriver_win32.zip');
       done();
+    });
   });
 
   it('should get the 87.0.4280.88, 64-bit, m1 version (arch = arm64)', (done) => {

--- a/spec/binaries/chrome_xml_spec.ts
+++ b/spec/binaries/chrome_xml_spec.ts
@@ -68,7 +68,7 @@ describe('chrome xml reader', () => {
 
   // This test case covers a bug when all the following conditions were true.
   //  arch was 64 with multiple major versions available.
-  fit('should note get the 85.0.4183.83, 32-bit version (arch = x64)', (done) => {
+  it('should not get the 85.0.4183.38, 32-bit version (arch = x64)', (done) => {
     let chromeXml = new ChromeXml();
     chromeXml.out_dir = out_dir;
     chromeXml.ostype = 'Windows_NT';

--- a/spec/binaries/chrome_xml_spec.ts
+++ b/spec/binaries/chrome_xml_spec.ts
@@ -65,4 +65,17 @@ describe('chrome xml reader', () => {
       done();
     });
   });
+
+  // This test case covers a bug when all the following conditions were true.
+  //  arch was 64 with multiple major versions available.
+  fit('should note get the 85.0.4183.83, 32-bit version (arch = x64)', (done) => {
+    let chromeXml = new ChromeXml();
+    chromeXml.out_dir = out_dir;
+    chromeXml.ostype = 'Windows_NT';
+    chromeXml.osarch = 'x64';
+    chromeXml.getUrl('85.0.4183.87').then((binaryUrl) => {
+      expect(binaryUrl.url).toContain('85.0.4183.87/chromedriver_win32.zip');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Attempt to fix #472 - with more context specifically at https://github.com/angular/webdriver-manager/issues/472#issuecomment-685225125