### PR TITLE
fix(chromedriver): use chromedriver patch version as semver pre-release version

### DIFF
--- a/lib/binaries/chrome_xml.ts
+++ b/lib/binaries/chrome_xml.ts
@@ -129,11 +129,12 @@ export class ChromeXml extends XmlConfigSource {
  * Chromedriver is the only binary that does not conform to semantic versioning
  * and either has too little number of digits or too many. To get this to be in
  * semver, we will either add a '.0' at the end or chop off the last set of
- * digits. This is so we can compare to find the latest and greatest.
+ * digits (the patch number) and use it as a pre-release version. This is so we
+ * can compare to find the latest and greatest.
  *
  * Example:
  *   2.46 -> 2.46.0
- *   75.0.3770.8 -> 75.0.3770
+ *   75.0.3770.8 -> 75.0.3770-patch.8
  *
  * @param version
  */
@@ -151,10 +152,10 @@ export function getValidSemver(version: string): string {
   }
   // This supports downloading 74.0.3729.6
   try {
-    const newRegex = /(\d+.\d+.\d+).\d+/g;
+    const newRegex = /(\d+.\d+.\d+).(\d+)/g;
     const exec = newRegex.exec(version);
     if (exec) {
-      lookUpVersion = exec[1];
+      lookUpVersion = `${exec[1]}-patch.${exec[2]}`;
     }
   } catch (_) {
     // no-op: if this does not work, use the other regex pattern.

--- a/lib/cmds/status.ts
+++ b/lib/cmds/status.ts
@@ -95,7 +95,7 @@ function status(options: Options) {
       if (semver.gt(a, b)) {
         return 1;
       } else {
-        return 0;
+        return -1;
       }
     });
     for (let ver in downloaded.versions) {

--- a/spec/binaries/chrome_xml_spec.ts
+++ b/spec/binaries/chrome_xml_spec.ts
@@ -90,4 +90,15 @@ describe('chrome xml reader', () => {
       done();
     });
   });
+
+  it('should get the 91.0.4472.101, 64-bit, m1 version (arch = arm64)', (done) => {
+    let chromeXml = new ChromeXml();
+    chromeXml.out_dir = out_dir;
+    chromeXml.ostype = 'Darwin';
+    chromeXml.osarch = 'arm64';
+    chromeXml.getUrl('91.0.4472.101').then((binaryUrl) => {
+      expect(binaryUrl.url).toContain('91.0.4472.101/chromedriver_mac64_m1.zip');
+      done();
+    });
+  });
 });

--- a/spec/cmds/status_spec.ts
+++ b/spec/cmds/status_spec.ts
@@ -33,7 +33,7 @@ describe('status', () => {
         .catch(err => {
           done.fail();
         });
-  });
+  }, 30000);
 
   it('should show the version number of the default and latest versions', () => {
     let lines =


### PR DESCRIPTION
**Issue:**
While trying to download Chromedriver version `91.0.4472.101`, version `91.0.4472.19` is being downloaded instead, because:

- Chromedriver patch version is not being considerer
- Chromedriver version `91.0.4472.101` is listed before version `91.0.4472.19`

![image](https://user-images.githubusercontent.com/2792526/122196849-814ec380-ce8f-11eb-8b30-b8d0156af937.png)

**Proposed solution:**
Update `getValidSemver` so it generates semver versions that include all 4 Chromedriver version numbers:
`<MAJOR>.<MINOR>.<BUILD>.<PATCH>`

Chromedriver semver versions will always use the pre-release format:
`<MAJOR>.<MINOR>.<BUILD>-patch.<PATCH>`

Version precedence will include all 4 number as per: 
Semantic Versioning 2.0.0 definition, section 11, sub-section 4
https://semver.org/#spec-item-11

**Fixes:**
https://github.com/angular/webdriver-manager/pull/413
https://github.com/angular/webdriver-manager/issues/496
https://github.com/angular/webdriver-manager/issues/497