### PR TITLE
Fix the vulnerabiltiy issue discussed in #499

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "author": "Craig Nishina <craig.nishina@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "adm-zip": "^0.4.9",
+    "adm-zip": "^0.5.2",
     "chalk": "^1.1.1",
     "del": "^2.2.0",
     "glob": "^7.0.3",


### PR DESCRIPTION
Ugrade adm-zip ^0.4.9 ➔ ^0.5.2, since adm-zip@0.5.2(>=0.5.2) has fixed the vulnerability SNYK-JS-ADMZIP-1065796.