### PR TITLE
updated xml2js to 0.5.0 and other libraries to prevent vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriver-manager",
-  "version": "12.1.9",
+  "version": "12.1.10",
   "description": "A selenium server and browser driver manager for your end to end tests.",
   "scripts": {
     "format": "gulp format",
@@ -42,14 +42,14 @@
     "adm-zip": "^0.5.2",
     "chalk": "^1.1.1",
     "del": "^2.2.0",
-    "glob": "^7.0.3",
+    "glob": "^7.2.3",
     "ini": "^1.3.4",
     "minimist": "^1.2.0",
     "q": "^1.4.1",
     "request": "^2.87.0",
     "rimraf": "^2.5.2",
     "semver": "^5.3.0",
-    "xml2js": "^0.4.17"
+    "xml2js": "^0.5.0"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.0",
@@ -68,11 +68,11 @@
     "@types/semver": "^5.3.30",
     "@types/xml2js": "0.0.32",
     "clang-format": "^1.0.35",
-    "gulp": "^4.0.0",
+    "gulp": "^4.0.2",
     "gulp-clang-format": "^1.0.23",
     "jasmine": "^2.4.1",
     "run-sequence": "^1.1.5",
-    "selenium-webdriver": "~3.0.1",
+    "selenium-webdriver": "^3.6.0",
     "typescript": "~2.3.0"
   },
   "engines": {


### PR DESCRIPTION
updated xml2js to 0.5.0 and other libraries to prevent vulnerability [CVE-2023-0842] (https://github.com/advisories/GHSA-776f-qx25-q3cc)